### PR TITLE
Automatically correct n in simpsons boole

### DIFF
--- a/torchquad/integration/boole.py
+++ b/torchquad/integration/boole.py
@@ -17,33 +17,28 @@ class Boole(BaseIntegrator):
     def __init__(self):
         super().__init__()
 
-    def integrate(self, fn, dim, N=5, integration_domain=None):
-        """Integrates the passed function on the passed domain using Boole's rule
+    def integrate(self, fn, dim, N=None, integration_domain=None):
+        """Integrates the passed function on the passed domain using Boole's rule.
 
         Args:
             fn (func): The function to integrate over.
             dim (int): Dimensionality of the integration domain.
-            N (int, optional): Number of sample points to use for the integration. N has to be such as N^(1/dim) - 1 % 4 == 0. Defaults to 5 for dim = 1.
-            integration_domain (list, optional): Integration domain. Defaults to [-1,1]^dim.
+            N (int, optional): Total number of sample points to use for the integration. N has to be such that N^(1/dim) - 1 % 4 == 0. Defaults to 5 points per dimension if None is given.
+            integration_domain (list, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim.
 
         Returns:
-            float: Integral value
+            float: Integral value.
         """
-        self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
-        self._integration_domain = setup_integration_domain(dim, integration_domain)
 
-        logger.debug(
-            "Using Boole for integrating a fn with "
-            + str(N)
-            + " points over "
-            + str(integration_domain)
-        )
+        # If N is unspecified, set N to 5 points per dimension
+        if N is None:
+            N = 5**dim
+
+        self._integration_domain = setup_integration_domain(dim, integration_domain)
+        self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
 
         self._dim = dim
         self._fn = fn
-
-        # Create grid and assemble evaluation points
-        self._grid = IntegrationGrid(N, integration_domain)
 
         #Check on the grid_N size
         if (self._grid._N - 1) % 4 > 0:
@@ -52,6 +47,17 @@ class Boole(BaseIntegrator):
                     f"N was {self._grid._N}. N has to be such as N^(1/dim) - 1 % 4 == 0."
                 )
             )
+
+        logger.debug(
+            "Using Boole for integrating a fn with "
+            + str(N)
+            + " points over "
+            + str(integration_domain)
+            + "."
+        )
+
+        # Create grid and assemble evaluation points
+        self._grid = IntegrationGrid(N, integration_domain)
 
         logger.debug("Evaluating integrand on the grid")
         function_values = self._eval(self._grid.points)

--- a/torchquad/integration/boole.py
+++ b/torchquad/integration/boole.py
@@ -37,7 +37,7 @@ class Boole(BaseIntegrator):
 
         self._integration_domain = setup_integration_domain(dim, integration_domain)
         self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
-        self._adjust_N(dim=dim, N=N)
+        N = self._adjust_N(dim=dim, N=N)
 
         self._dim = dim
         self._fn = fn

--- a/torchquad/integration/boole.py
+++ b/torchquad/integration/boole.py
@@ -92,23 +92,23 @@ class Boole(BaseIntegrator):
         Returns:
             int: An N satisfying N^(1/dim) - 1 % 4 == 0.
         """
-        Nperdim = int(N ** (1.0 / dim) + 1e-8)
+        n_per_dim = int(N ** (1.0 / dim) + 1e-8)
         logger.debug("Checking if N per dim is >=5 and N = 1 + 4n, where n is a positive integer.")        
 
         # Boole's rule requires N per dim >=5 and N = 1 + 4n, 
         # where n is a positive integer, for correctness.
-        if Nperdim < 5: 
+        if n_per_dim < 5: 
             warnings.warn(
                     "N per dimension cannot be lower than 5. "
                     "N per dim will now be changed to 5."
             )
             N = 5**dim
-        elif (Nperdim - 1) % 4 != 0:
-            new_Nperdim = Nperdim - ((Nperdim - 1) % 4)
+        elif (n_per_dim - 1) % 4 != 0:
+            new_n_per_dim = n_per_dim - ((n_per_dim - 1) % 4)
             warnings.warn(
                     "N per dimension must be N = 1 + 4n with n a positive integer due to necessary subdivisions. "
                     "N per dim will now be changed to the next lower N satisfying this, i.e. "
-                    f"{Nperdim} -> {new_Nperdim}."
+                    f"{n_per_dim} -> {new_n_per_dim}."
             )
-            N = (new_Nperdim)**(dim)
+            N = (new_n_per_dim)**(dim)
         return N

--- a/torchquad/integration/boole.py
+++ b/torchquad/integration/boole.py
@@ -5,6 +5,7 @@ from .utils import setup_integration_domain
 import torch
 
 import logging
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -36,20 +37,13 @@ class Boole(BaseIntegrator):
 
         self._integration_domain = setup_integration_domain(dim, integration_domain)
         self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
+        self._adjust_N(dim=dim, N=N)
 
         self._dim = dim
         self._fn = fn
 
-        #Check on the grid_N size
-        if (self._grid._N - 1) % 4 > 0:
-            raise (
-                ValueError(
-                    f"N was {self._grid._N}. N has to be such as N^(1/dim) - 1 % 4 == 0."
-                )
-            )
-
         logger.debug(
-            "Using Boole for integrating a fn with "
+            "Using Boole for integrating a fn with a total of "
             + str(N)
             + " points over "
             + str(integration_domain)
@@ -59,14 +53,15 @@ class Boole(BaseIntegrator):
         # Create grid and assemble evaluation points
         self._grid = IntegrationGrid(N, integration_domain)
 
-        logger.debug("Evaluating integrand on the grid")
+        logger.debug("Evaluating integrand on the grid.")
         function_values = self._eval(self._grid.points)
 
         # Reshape the output to be [N,N,...] points instead of [dim*N] points
         function_values = function_values.reshape([self._grid._N] * dim)
 
-        logger.debug("Computing areas")
+        logger.debug("Computing areas.")
 
+        # This will contain the Simpson's areas per dimension
         cur_dim_areas = function_values
 
         # We collapse dimension by dimension
@@ -83,6 +78,37 @@ class Boole(BaseIntegrator):
                 )
             )
             cur_dim_areas = torch.sum(cur_dim_areas, dim=dim - cur_dim - 1)
-        logger.info("Computed integral was " + str(cur_dim_areas))
+        logger.info("Computed integral was " + str(cur_dim_areas) + ".")
 
         return cur_dim_areas
+
+    def _adjust_N(self, dim, N):
+        """Adjusts the total number of points to a valid number, i.e. N satisfies N^(1/dim) - 1 % 4 == 0. 
+
+        Args:
+            dim (int): Dimensionality of the integration domain.
+            N (int): Total number of sample points to use for the integration.
+            
+        Returns:
+            int: An N satisfying N^(1/dim) - 1 % 4 == 0.
+        """
+        Nperdim = int(N ** (1.0 / dim) + 1e-8)
+        logger.debug("Checking if N per dim is >=5 and N = 1 + 4n, where n is a positive integer.")        
+
+        # Boole's rule requires N per dim >=5 and N = 1 + 4n, 
+        # where n is a positive integer, for correctness.
+        if Nperdim < 5: 
+            warnings.warn(
+                    "N per dimension cannot be lower than 5. "
+                    "N per dim will now be changed to 5."
+            )
+            N = 5**dim
+        elif (Nperdim - 1) % 4 != 0:
+            new_Nperdim = Nperdim - ((Nperdim - 1) % 4)
+            warnings.warn(
+                    "N per dimension must be N = 1 + 4n with n a positive integer due to necessary subdivisions. "
+                    "N per dim will now be changed to the next lower N satisfying this, i.e. "
+                    f"{Nperdim} -> {new_Nperdim}."
+            )
+            N = (new_Nperdim)**(dim)
+        return N

--- a/torchquad/integration/simpson.py
+++ b/torchquad/integration/simpson.py
@@ -90,23 +90,23 @@ class Simpson(BaseIntegrator):
         Returns:
             int: An odd N >3.
         """
-        Nperdim = int(N ** (1.0 / dim) + 1e-8)
+        n_per_dim = int(N ** (1.0 / dim) + 1e-8)
         logger.debug("Checking if N per dim is >=3 and odd.")        
 
         # Simpson's rule requires odd N per dim >3 for correctness. There is a more 
         # complex rule that works for even N as well but it is not implemented here.
-        if Nperdim < 3: 
+        if n_per_dim < 3: 
             warnings.warn(
                     "N per dimension cannot be lower than 3. "
                     "N per dim will now be changed to 3."
             )
             N = 3**dim
-        elif Nperdim % 2 != 1:
+        elif n_per_dim % 2 != 1:
             warnings.warn(
                     "N per dimension cannot be even due to necessary subdivisions. "
                     "N per dim will now be changed to the next lower integer, i.e. "
-                    f"{Nperdim} -> {Nperdim - 1}."
+                    f"{n_per_dim} -> {n_per_dim - 1}."
             )
-            N = (Nperdim - 1)**(dim)
+            N = (n_per_dim - 1)**(dim)
         return N
         

--- a/torchquad/integration/simpson.py
+++ b/torchquad/integration/simpson.py
@@ -37,7 +37,7 @@ class Simpson(BaseIntegrator):
 
         self._integration_domain = setup_integration_domain(dim, integration_domain)
         self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
-        self._adjust_N(dim=dim, N=N)
+        N = self._adjust_N(dim=dim, N=N)
 
         self._dim = dim
         self._fn = fn

--- a/torchquad/integration/trapezoid.py
+++ b/torchquad/integration/trapezoid.py
@@ -16,26 +16,27 @@ class Trapezoid(BaseIntegrator):
     def __init__(self):
         super().__init__()
 
-    def integrate(self, fn, dim, N=2, integration_domain=None):
-        """Integrates the passed function on the passed domain using the trapezoid rule
+    def integrate(self, fn, dim, N=1000, integration_domain=None):
+        """Integrates the passed function on the passed domain using the trapezoid rule.
 
         Args:
-            fn (func): The function to integrate over
-            dim (int): Dimensionality of the function to integrate
-            N (int, optional): Number of sample points to use for the integration. Defaults to 1000.
+            fn (func): The function to integrate over.
+            dim (int): Dimensionality of the function to integrate.
+            N (int, optional): Total number of sample points to use for the integration. Defaults to 1000.
             integration_domain (list, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim.
 
         Returns:
-            float: Integral value
+            float: Integral value.
         """
-        self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
         self._integration_domain = setup_integration_domain(dim, integration_domain)
+        self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
 
         logger.debug(
             "Using Trapezoid for integrating a fn with "
             + str(N)
             + " points over "
             + str(integration_domain)
+            + "."
         )
 
         self._dim = dim
@@ -44,14 +45,14 @@ class Trapezoid(BaseIntegrator):
         # Create grid and assemble evaluation points
         self._grid = IntegrationGrid(N, integration_domain)
 
-        logger.debug("Evaluating integrand on the grid")
+        logger.debug("Evaluating integrand on the grid.")
         function_values = self._eval(self._grid.points)
 
         # Reshape the output to be [N,N,...] points
         # instead of [dim*N] points
         function_values = function_values.reshape([self._grid._N] * dim)
 
-        logger.debug("Computing trapezoid areas")
+        logger.debug("Computing trapezoid areas.")
 
         # This will contain the trapezoid areas per dimension
         cur_dim_areas = function_values
@@ -65,6 +66,6 @@ class Trapezoid(BaseIntegrator):
             )
             cur_dim_areas = torch.sum(cur_dim_areas, dim=dim - cur_dim - 1)
 
-        logger.info("Computed integral was " + str(cur_dim_areas))
+        logger.info("Computed integral was " + str(cur_dim_areas) + ".")
 
         return cur_dim_areas

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -1,4 +1,4 @@
-"""This file contains various utility functions for the integrations methods"""
+"""This file contains various utility functions for the integrations methods."""
 
 import torch
 import logging
@@ -7,13 +7,23 @@ logger = logging.getLogger(__name__)
 
 
 def setup_integration_domain(dim, integration_domain):
+    """Sets up the integration domain if unspecified by the user.
+
+    Args:
+        dim (int): Dimensionality of the integration domain.
+        integration_domain (list, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim.
+
+    Returns:
+        torch.tensor: Integration domain.
+    """
+
     # Store integration_domain
     # If not specified, create [-1,1]^d bounds
-    logger.debug("Setting up integration domain")
+    logger.debug("Setting up integration domain.")
     if integration_domain is not None:
         if len(integration_domain) != dim:
             raise ValueError(
-                "Dimension and length of integration domain don't match. Should be e.g. dim=1 dom=[[-1,1]]"
+                "Dimension and length of integration domain don't match. Should be e.g. dim=1 dom=[[-1,1]]."
             )
         if type(integration_domain) == torch.Tensor:
             return integration_domain

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -22,7 +22,7 @@ def test_integrate():
         assert error < 1e-11
 
     # 3D Tests
-    N = 1030340 # N = 101.001 per dim
+    N = 1030301 # N = 101 per dim
     errors = compute_test_errors(bl.integrate, {"N": N, "dim": 3}, dim=3)
     print("Passed N =", N, "\n", errors)
     for error in errors[:3]:

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -3,7 +3,7 @@ import sys
 sys.path.append("../")
 
 import torch
-
+import warnings
 
 from integration.boole import Boole
 from tests.integration_test_utils import compute_test_errors
@@ -22,8 +22,10 @@ def test_integrate():
         assert error < 1e-11
 
     # 3D Tests
-    N = 1030301 # N = 101 per dim
-    errors = compute_test_errors(bl.integrate, {"N": N, "dim": 3}, dim=3)
+    N = 1076890 # N = 102.5 per dim (will change to 101 if all works)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        errors = compute_test_errors(bl.integrate, {"N": N, "dim": 3}, dim=3)
     print("Passed N =", N, "\n", errors)
     for error in errors[:3]:
         assert error < 2e-13

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -17,14 +17,14 @@ def test_integrate():
     N = 401
 
     errors = compute_test_errors(bl.integrate, {"N": N, "dim": 1})
-    print("N =", N, "\n", errors)
+    print("Passed N =", N, "\n", errors)
     for error in errors:
         assert error < 1e-11
 
     # 3D Tests
-    N = 1030302
+    N = 1030340 # N = 101.001 per dim
     errors = compute_test_errors(bl.integrate, {"N": N, "dim": 3}, dim=3)
-    print("N =", N, "\n", errors)
+    print("Passed N =", N, "\n", errors)
     for error in errors[:3]:
         assert error < 2e-13
     for error in errors:

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -3,7 +3,7 @@ import sys
 sys.path.append("../")
 
 import torch
-
+import warnings
 
 from integration.simpson import Simpson
 from tests.integration_test_utils import compute_test_errors
@@ -30,8 +30,10 @@ def test_integrate():
         assert error < 1e-15
 
     # 3D Tests
-    N = 1030301  # N = 101 per dim
-    errors = compute_test_errors(simp.integrate, {"N": N, "dim": 3}, dim=3)
+    N = 1076890 # N = 102.5 per dim (will change to 101 if all works)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        errors = compute_test_errors(simp.integrate, {"N": N, "dim": 3}, dim=3)
     print("Passed N =", N, "\n", errors)
     for error in errors[:3]:
         assert error < 1e-12

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -17,22 +17,22 @@ def test_integrate():
     N = 100001
 
     errors = compute_test_errors(simp.integrate, {"N": N, "dim": 1})
-    print("N =", N, "\n", errors)
+    print("Passed N =", N, "\n", errors)
     for error in errors:
         assert error < 1e-7
 
     N = 3  # integration points, here 3 for order check (3 points should lead to almost 0 err for low order polynomials)
     errors = compute_test_errors(simp.integrate, {"N": N, "dim": 1})
-    print("N =", N, "\n", errors)
+    print("Passed N =", N, "\n", errors)
     # all polynomials up to degree = 3 should be 0
     # if this breaks check if test functions in integration_test_utils changed.
     for error in errors[:3]:
         assert error < 1e-15
 
     # 3D Tests
-    N = 1030300  # N = 101 per dim
+    N = 1030340  # N = 101.001 per dim
     errors = compute_test_errors(simp.integrate, {"N": N, "dim": 3}, dim=3)
-    print("N =", N, "\n", errors)
+    print("Passed N =", N, "\n", errors)
     for error in errors[:3]:
         assert error < 1e-12
     for error in errors:

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -30,7 +30,7 @@ def test_integrate():
         assert error < 1e-15
 
     # 3D Tests
-    N = 1030301  # N = 101 per dim
+    N = 1030300  # N = 101 per dim
     errors = compute_test_errors(simp.integrate, {"N": N, "dim": 3}, dim=3)
     print("N =", N, "\n", errors)
     for error in errors[:3]:

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -30,7 +30,7 @@ def test_integrate():
         assert error < 1e-15
 
     # 3D Tests
-    N = 1030340  # N = 101.001 per dim
+    N = 1030301  # N = 101 per dim
     errors = compute_test_errors(simp.integrate, {"N": N, "dim": 3}, dim=3)
     print("Passed N =", N, "\n", errors)
     for error in errors[:3]:


### PR DESCRIPTION
Updated Simpson's and Boole's so that it gives a warning if the N per dim is wrong, and then the N per dim is automatically corrected. 

Added description to torchquad/integration/utils.py.
Fixed a small mistake (N=2 but said it should be 1000) in Trapezoid.

And lastly, changed typos (mostly punctuation), including in simpson_test and boole_test and Trapezoid.