### PR TITLE
Add Boole to Integration list on RtD

### DIFF
--- a/docs/source/integration_methods.rst
+++ b/docs/source/integration_methods.rst
@@ -23,6 +23,14 @@ Monte Carlo Integrator
 Deterministic Methods
 ----------------------
 
+Boole's Rule
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: torchquad.Boole
+   :members:
+   :noindex:
+   
+
 Simpson's Rule
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Added Boole to the list of integration methods in Read the Docs.
This PR should be merged after #43 