### PR TITLE
Update integration_test_functions.py

### DIFF
--- a/torchquad/tests/integration_test_functions.py
+++ b/torchquad/tests/integration_test_functions.py
@@ -26,7 +26,7 @@ class IntegrationTestFunction:
         self.dim = dim
         self.expected_result = expected_result
         # Init domain to [-1,1]^dim if not passed
-        if domain == None:
+        if domain is None:
             self.domain = torch.tensor([[-1, 1]] * self.dim)
         else:
             self.domain = domain


### PR DESCRIPTION
**Consider using identity comparison with singleton**
Comparisons to the singleton objects, like True, False, and None, should be done with identity, not equality. Use is or is not.
Identity checks are faster than equality checks. Also, the equality checks can result in unintended behaviour in some cases.