### PR TITLE
Use different environment for rtd to avoid problems with cudatoolkit incompatibilities (latest)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,4 +20,4 @@ python:
       path: .
 
 conda:
-  environment: environment.yml
+  environment: rtd_environment.yml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,6 +64,6 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ copyright = "2021, Gabriele Meoni, Håvard Hem Toftevaag, Pablo Gómez  ."
 author = "ESA Advanced Concepts Team"
 
 # The full version, including alpha/beta/rc tags
-release = "0.2.1"
+release = "0.2.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/rtd_environment.yml
+++ b/rtd_environment.yml
@@ -1,0 +1,15 @@
+name: rtd_torchquad
+channels:
+- conda-forge
+- pytorch
+dependencies:
+- ipython
+- loguru>=0.5.3
+- matplotlib>=3.3.3
+- pytest>=6.2.1
+- python>=3.8
+- pytorch>=1.9
+- scipy>=1.6.0
+- sphinx>=3.4.3
+- sphinx_rtd_theme>=0.5.1
+- tqdm>=4.56.0


### PR DESCRIPTION
# Description

- Added separate environment for readthedocs to fix failing builds
- Fixed warnings in docs

## How Has This Been Tested?

- Built the docs locally

## Related PRs

#131 