### PR TITLE
Updated return types in docstirngs of .integrate functions according …

### DIFF
--- a/torchquad/integration/boole.py
+++ b/torchquad/integration/boole.py
@@ -24,7 +24,7 @@ class Boole(BaseIntegrator):
             integration_domain (list, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim.
 
         Returns:
-            float: integral value
+            torch.Tensor: integral value
         """
 
         # If N is unspecified, set N to 5 points per dimension

--- a/torchquad/integration/monte_carlo.py
+++ b/torchquad/integration/monte_carlo.py
@@ -25,7 +25,7 @@ class MonteCarlo(BaseIntegrator):
             ValueError: If len(integration_domain) != dim
 
         Returns:
-            float: integral value
+            torch.Tensor: integral value
         """
         self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
         logger.debug(

--- a/torchquad/integration/simpson.py
+++ b/torchquad/integration/simpson.py
@@ -24,7 +24,7 @@ class Simpson(BaseIntegrator):
             integration_domain (list, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim.
 
         Returns:
-            float: integral value
+            torch.Tensor: integral value
         """
 
         # If N is unspecified, set N to 3 points per dimension

--- a/torchquad/integration/trapezoid.py
+++ b/torchquad/integration/trapezoid.py
@@ -22,7 +22,7 @@ class Trapezoid(BaseIntegrator):
             integration_domain (list, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim.
 
         Returns:
-            float: integral value
+            torch.Tensor: integral value
         """
         self._integration_domain = _setup_integration_domain(dim, integration_domain)
         self._check_inputs(dim=dim, N=N, integration_domain=self._integration_domain)

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -48,7 +48,7 @@ class VEGAS(BaseIntegrator):
             ValueError: If len(integration_domain) != dim
 
         Returns:
-            float: Integral value
+            torch.Tensor: Integral value
         """
 
         self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)


### PR DESCRIPTION
Closes #138

# Description
The `.integrate` functions of classes `Boole`, `MonteCarlo`, `Simpson`, `Trapezoid`, and `VEGAS` have been reading `float`. However, they return a `torch.Tensor`. When using `torchquad` integrators in IDEs that use intellisense or comparable syntax highlighting tools, the user usually receives warnings from calling `torch.Tensor`-related operations such as `.backward()` or `.item()` on the `.integrate()` output, which by the syntax checker is expected to be a `float`.

Summary of changes
* Changed the return type in the docstring of the `.integrate` function of classes `Boole`, `MonteCarlo`, `Simpson`, `Trapezoid`, and `VEGAS` from `float` to `torch.Tensor`.

## Resolved Issues
- [ ] fixes #138 

## How Has This Been Tested?
Since no actual code was changed but only docstrings, the auto-tests should provide sufficient testing.

