### PR TITLE
Change the backend argument behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Note also that installing PyTorch with *pip* may **not** set it up with CUDA sup
 Here are installation instructions for other numerical backends:
    ```sh
    conda install "tensorflow>=2.6.0=cuda*" -c conda-forge
-   pip install "jax[cuda]>=0.2.22" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html # linux only
+   pip install "jax[cuda]>=0.2.22" --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html # linux only
    conda install "numpy>=1.19.5" -c conda-forge
    ```
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -57,7 +57,7 @@ Here are installation instructions for other numerical backends:
    .. code-block:: bash
 
       conda install "tensorflow>=2.6.0=cuda*" -c conda-forge
-      pip install "jax[cuda]>=0.2.22" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html # linux only
+      pip install "jax[cuda]>=0.2.22" --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html # linux only
       conda install "numpy>=1.19.5" -c conda-forge
 
 More installation instructions for numerical backends can be found in

--- a/environment_all_backends.yml
+++ b/environment_all_backends.yml
@@ -20,5 +20,5 @@ dependencies:
 - tensorflow-gpu>=2.6.0
 # jaxlib with CUDA support is not available for conda
 - pip:
-  - --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
+  - --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
   - jax[cuda]>=0.2.22 # this will only work on linux. for win see e.g. https://github.com/cloudhan/jax-windows-builder

--- a/torchquad/integration/boole.py
+++ b/torchquad/integration/boole.py
@@ -19,8 +19,8 @@ class Boole(NewtonCotes):
             fn (func): The function to integrate over.
             dim (int): Dimensionality of the integration domain.
             N (int, optional): Total number of sample points to use for the integration. N has to be such that N^(1/dim) - 1 % 4 == 0. Defaults to 5 points per dimension if None is given.
-            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It can also determine the numerical backend.
+            backend (string, optional): Numerical backend. Defaults to integration_domain's backend if it is a tensor and otherwise to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
 
         Returns:
             backend-specific number: Integral value

--- a/torchquad/integration/monte_carlo.py
+++ b/torchquad/integration/monte_carlo.py
@@ -29,10 +29,10 @@ class MonteCarlo(BaseIntegrator):
             fn (func): The function to integrate over.
             dim (int): Dimensionality of the function to integrate.
             N (int, optional): Number of sample points to use for the integration. Defaults to 1000.
-            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
+            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It can also determine the numerical backend.
             seed (int, optional): Random number generation seed to the sampling point creation, only set if provided. Defaults to None.
             rng (RNG, optional): An initialised RNG; this can be used when compiling the function for Tensorflow
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+            backend (string, optional): Numerical backend. Defaults to integration_domain's backend if it is a tensor and otherwise to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
 
         Raises:
             ValueError: If len(integration_domain) != dim
@@ -119,9 +119,9 @@ class MonteCarlo(BaseIntegrator):
         Args:
             dim (int): Dimensionality of the integration domain.
             N (int, optional): Number of sample points to use for the integration. Defaults to 1000.
-            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
+            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It can also determine the numerical backend.
             seed (int, optional): Random number generation seed for the sequence of sampling point calculations, only set if provided. The returned integrate function calculates different points in each invocation with and without specified seed. Defaults to None.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+            backend (string, optional): Numerical backend. Defaults to integration_domain's backend if it is a tensor and otherwise to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
 
         Returns:
             function(fn, integration_domain): JIT compiled integrate function where all parameters except the integrand and domain are fixed

--- a/torchquad/integration/newton_cotes.py
+++ b/torchquad/integration/newton_cotes.py
@@ -97,8 +97,8 @@ class NewtonCotes(BaseIntegrator):
         Args:
             dim (int): Dimensionality of the integration domain.
             N (int, optional): Total number of sample points to use for the integration. See the integrate method documentation for more details.
-            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It can also determine the numerical backend.
+            backend (string, optional): Numerical backend. Defaults to integration_domain's backend if it is a tensor and otherwise to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
 
         Returns:
             function(fn, integration_domain): JIT compiled integrate function where all parameters except the integrand and domain are fixed

--- a/torchquad/integration/simpson.py
+++ b/torchquad/integration/simpson.py
@@ -19,8 +19,8 @@ class Simpson(NewtonCotes):
             fn (func): The function to integrate over.
             dim (int): Dimensionality of the integration domain.
             N (int, optional): Total number of sample points to use for the integration. Should be odd. Defaults to 3 points per dimension if None is given.
-            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It can also determine the numerical backend.
+            backend (string, optional): Numerical backend. Defaults to integration_domain's backend if it is a tensor and otherwise to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
 
         Returns:
             backend-specific number: Integral value

--- a/torchquad/integration/trapezoid.py
+++ b/torchquad/integration/trapezoid.py
@@ -16,8 +16,8 @@ class Trapezoid(NewtonCotes):
             fn (func): The function to integrate over.
             dim (int): Dimensionality of the function to integrate.
             N (int, optional): Total number of sample points to use for the integration. Defaults to 1000.
-            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It can also determine the numerical backend.
+            backend (string, optional): Numerical backend. Defaults to integration_domain's backend if it is a tensor and otherwise to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
 
         Returns:
             backend-specific number: Integral value

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -103,8 +103,8 @@ def _setup_integration_domain(dim, integration_domain, backend):
     """Sets up the integration domain if unspecified by the user.
     Args:
         dim (int): Dimensionality of the integration domain.
-        integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
-        backend (string or None): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. If set to None, use the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+        integration_domain (list or backend tensor or None): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It can also determine the numerical backend.
+        backend (string or None): Numerical backend. If set to None, use integration_domain's backend if it is a tensor and otherwise use the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
     Returns:
         backend tensor: Integration domain.
     """
@@ -114,8 +114,20 @@ def _setup_integration_domain(dim, integration_domain, backend):
     if integration_domain is None:
         integration_domain = [[-1.0, 1.0]] * dim
 
+    # Give an explicitly set backend argument higher precedence than
+    # integration_domain's backend.
+    # If the backend argument is not None, the dtype of integration_domain is
+    # ignored unless its backend and the backend argument are the same.
+    domain_arg_backend = infer_backend(integration_domain)
+    convert_to_tensor = domain_arg_backend == "builtins"
+    if not convert_to_tensor and backend is not None and domain_arg_backend != backend:
+        logger.warning(
+            "integration_domain should be a list when the backend argument is set."
+        )
+        convert_to_tensor = True
+
     # Convert integration_domain to a tensor if needed
-    if infer_backend(integration_domain) == "builtins":
+    if convert_to_tensor:
         # Cast all integration domain values to Python3 float because
         # some numerical backends create a tensor based on the Python3 types
         integration_domain = [

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -58,7 +58,7 @@ class VEGAS(BaseIntegrator):
             eps_abs (float, optional): Absolute error to abort at. Defaults to 0.
             max_iterations (int, optional): Maximum number of vegas iterations to perform. The number of performed iterations is usually lower than this value because the number of sample points per iteration increases every fifth iteration. Defaults to 20.
             use_warmup (bool, optional): If True, execute a warmup to initialize the vegas map. Defaults to True.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. "jax" and "tensorflow" are unsupported. Defaults to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+            backend (string, optional): Numerical backend. "jax" and "tensorflow" are unsupported. Defaults to integration_domain's backend if it is a tensor and otherwise to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
 
         Raises:
             ValueError: If the integration_domain or backend argument is invalid

--- a/torchquad/tests/integration_test_functions.py
+++ b/torchquad/tests/integration_test_functions.py
@@ -22,16 +22,16 @@ class IntegrationTestFunction:
     is_complex = False  # If the test function contains complex numbers
 
     def __init__(
-        self, expected_result, dim=1, domain=None, is_complex=False, backend="torch"
+        self, expected_result, dim=1, domain=None, is_complex=False, backend=None
     ):
         """Initializes domain and stores variables.
 
         Args:
             expected_result (float): Expected integration result.
             dim (int, optional): Dimensionality of investigated function. Defaults to 1.
-            domain (list, optional): Integration domain, e.g. [[0,1],[1,2]]. Defaults to None.
+            domain (list or backend tensor, optional): Integration domain passed to _setup_integration_domain.
             is_complex (Boolean): If the test function contains complex numbers. Defaults to False.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from domain. Defaults to "torch".
+            backend (string, optional): Numerical backend passed to _setup_integration_domain.
         """
         self.dim = dim
         self.expected_result = expected_result
@@ -91,7 +91,7 @@ class Polynomial(IntegrationTestFunction):
         dim=1,
         domain=None,
         is_complex=False,
-        backend="torch",
+        backend=None,
     ):
         """Creates an n-dimensional, degree-K poylnomial test function.
 
@@ -99,9 +99,9 @@ class Polynomial(IntegrationTestFunction):
             expected_result (backend tensor): Expected result. Required to compute errors.
             coeffs (list, optional): Polynomial coefficients. Are the same for each dim. Defaults to [2].
             dim (int, optional): Polynomial dimensionality. Defaults to 1.
-            domain (list, optional): Integration domain. Defaults to [-1.0, 1.0]^dim.
+            domain (list or backend tensor, optional): Integration domain passed to _setup_integration_domain.
             is_complex (Boolean): If the test function contains complex numbers. Defaults to False.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from domain. Defaults to "torch".
+            backend (string, optional): Numerical backend.
         """
         super().__init__(expected_result, dim, domain, is_complex, backend)
         if backend == "tensorflow":
@@ -155,16 +155,16 @@ class Exponential(IntegrationTestFunction):
         dim=1,
         domain=None,
         is_complex=False,
-        backend="torch",
+        backend=None,
     ):
         """Creates an n-dimensional exponential test function.
 
         Args:
             expected_result (backend tensor): Expected result. Required to compute errors.
             dim (int, optional): Input dimension. Defaults to 1.
-            domain (list, optional): Integration domain. Defaults to [-1.0, 1.0]^dim.
+            domain (list or backend tensor, optional): Integration domain passed to _setup_integration_domain.
             is_complex (Boolean): If the test function contains complex numbers. Defaults to False.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from domain. Defaults to "torch".
+            backend (string, optional): Numerical backend passed to _setup_integration_domain.
         """
         super().__init__(expected_result, dim, domain, is_complex, backend)
         self.f = self._exp
@@ -181,16 +181,16 @@ class Sinusoid(IntegrationTestFunction):
         dim=1,
         domain=None,
         is_complex=False,
-        backend="torch",
+        backend=None,
     ):
         """Creates an n-dimensional sinusoidal test function.
 
         Args:
             expected_result (backend tensor): Expected result. Required to compute errors.
             dim (int, optional): Input dimension. Defaults to 1.
-            domain (list, optional): Integration domain. Defaults to [-1.0, 1.0]^dim.
+            domain (list or backend tensor, optional): Integration domain passed to _setup_integration_domain.
             is_complex (Boolean): If the test function contains complex numbers. Defaults to False.
-            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from domain. Defaults to "torch".
+            backend (string, optional): Numerical backend passed to _setup_integration_domain.
         """
         super().__init__(expected_result, dim, domain, is_complex, backend)
         self.f = self._sinusoid


### PR DESCRIPTION
# Description

This affects situations where a user explicitly specifies the `backend` argument and uses a tensor for `integration_domain` at the same time.
* If the `integration_domain`'s backend does not correspond to the `backend` argument value, prefer the `backend` argument and show a warning.
  In this case the `integration_domain`'s dtype is ignored, so a globally configured dtype is used instead.
* If the `integration_domain`'s backend corresponds to the `backend` argument value, ignore the `backend` argument.
  In this case the `integration_domain`'s dtype is used and a globally configured dtype is ignored.


## Resolved Issues

-  fixes #153

## How Has This Been Tested?

-  Additional tests in `utils_integration_test.py`

