### PR TITLE
(fix): use `static_argnums` for `jax` `jit`

### DIFF
--- a/torchquad/integration/newton_cotes.py
+++ b/torchquad/integration/newton_cotes.py
@@ -148,7 +148,7 @@ class NewtonCotes(BaseIntegrator):
                         self.calculate_grid, static_argnames=["N"]
                     )
                     self._jax_jit_calculate_result = jax.jit(
-                        self.calculate_result, static_argnames=["dim", "n_per_dim"]
+                        self.calculate_result, static_argnums=(1, 2,) # dim and n_per_dim
                     )
                 jit_calculate_grid = self._jax_jit_calculate_grid
                 jit_calculate_result = self._jax_jit_calculate_result


### PR DESCRIPTION
# Description

Because of the [`expand_func_values_and_squeeze_integral`](https://github.com/esa/torchquad/blob/develop/torchquad/integration/utils.py#L240) decorator on [`calculate_result`](https://github.com/esa/torchquad/blob/develop/torchquad/integration/newton_cotes.py#L38-L39), the `jax` JIT has no way of knowing what is `n_per_dim` or `dim` so we switch to numbered static arguments.

Summary of changes

* ... 
* ...

## Resolved Issues

- [ ] Towards the problem prompting #164

## How Has This Been Tested?

- [ ] Test A
- [ ] Test B

## Related Pull Requests

- #PR
