### PR TITLE
grid_integrator: Allow passing custom arguments to integrand function.

### DIFF
--- a/torchquad/integration/grid_integrator.py
+++ b/torchquad/integration/grid_integrator.py
@@ -28,7 +28,7 @@ class GridIntegrator(BaseIntegrator):
     def _weights(self, N, dim, backend, requires_grad=False):
         return None
 
-    def integrate(self, fn, dim, N, integration_domain, backend):
+    def integrate(self, fn, dim, N, integration_domain, backend, args=None):
         """Integrate the passed function on the passed domain using a Composite Newton Cotes rule.
         The argument meanings are explained in the sub-classes.
 
@@ -47,7 +47,7 @@ class GridIntegrator(BaseIntegrator):
 
         logger.debug("Evaluating integrand on the grid.")
         function_values, num_points = self.evaluate_integrand(
-            fn, grid_points, weights=self._weights(n_per_dim, dim, backend)
+            fn, grid_points, weights=self._weights(n_per_dim, dim, backend), args=args
         )
         self._nr_of_fevals = num_points
 


### PR DESCRIPTION
This allows avoiding the invocation of a lambda wrapper function. 
The commit just exposes an already existing functionality.

Also related to #187 
