### PR TITLE
Update `jax` config import

### DIFF
--- a/torchquad/utils/set_precision.py
+++ b/torchquad/utils/set_precision.py
@@ -55,9 +55,9 @@ def set_precision(data_type="float32", backend="torch"):
         )
         torch.set_default_tensor_type(tensor_dtype)
     elif backend == "jax":
-        from jax.config import config
+        from jax import config
 
-        config.update("jax_enable_x64", data_type == "float64")
+        config.update("jax_enable_x64", True)
         logger.info(f"JAX data type set to {data_type}")
     elif backend in ["numpy", "tensorflow"]:
         os.environ[f"TORCHQUAD_DTYPE_{backend.upper()}"] = data_type


### PR DESCRIPTION
This PR changes the import statement for `jax.config`, which resolves the error
```
File "/usr/local/lib/python3.10/dist-packages/torchquad/utils/set_precision.py", line 58, in set_precision
    from jax.config import config
ImportError: cannot import name 'config' from 'jax.config' (/usr/local/lib/python3.10/dist-packages/jax/config.py)
```