### PR TITLE
Update set_precision.py

### DIFF
--- a/torchquad/utils/set_precision.py
+++ b/torchquad/utils/set_precision.py
@@ -55,7 +55,7 @@ def set_precision(data_type="float32", backend="torch"):
         )
         torch.set_default_tensor_type(tensor_dtype)
     elif backend == "jax":
-        from jax.config import config
+        from jax import config
 
         config.update("jax_enable_x64", data_type == "float64")
         logger.info(f"JAX data type set to {data_type}")


### PR DESCRIPTION
# Description
I believe `from jax.config import config` is a typo and it should be changed to `from jax import config`.


Summary of changes

* changed `from jax.config import config` -> `from jax import config`


## Resolved Issues

- solves an import issue with the jax backend

