### PR TITLE
Fix jax.config submodule error

### DIFF
--- a/torchquad/utils/set_precision.py
+++ b/torchquad/utils/set_precision.py
@@ -55,7 +55,7 @@ def set_precision(data_type="float32", backend="torch"):
         )
         torch.set_default_tensor_type(tensor_dtype)
     elif backend == "jax":
-        from jax.config import config
+        from jax import config
 
         config.update("jax_enable_x64", data_type == "float64")
         logger.info(f"JAX data type set to {data_type}")


### PR DESCRIPTION
# Description

Summary of changes

* jax.config submodule is no longer available. Import config directly form jax instead.

## Resolved Issues

- [x] fixes #206

## How Has This Been Tested?

- Locally on my computer with jax-0.4.35 and torchquad 0.4.0
