### PR TITLE
Fix Gaussian integrator on jax

### DIFF
--- a/torchquad/integration/gaussian.py
+++ b/torchquad/integration/gaussian.py
@@ -65,7 +65,7 @@ class Gaussian(GridIntegrator):
             ).ravel()
         else:
             return anp.prod(
-                anp.meshgrid(*([weights] * dim), like=backend), axis=0
+                anp.stack(anp.meshgrid(*([weights] * dim), like=backend)), axis=0
             ).ravel()
 
     def _roots(self, N, backend, requires_grad=False):


### PR DESCRIPTION
# Description

Gaussian and GaussLegendre integrators throw an error on jax if anp.prod is called on a list instead of an array

Summary of changes

* Before calling `anp.prod`, use `anp.stack` to convert list of arrays into an array.

## Resolved Issues

- [x] fixes #214

## How Has This Been Tested?

- [ ] Untested

**IMPORTANT**: This change could potentially affect the behavior of other backends.
