### PR TITLE
fix: close quick 0.6 issues (logging #184, imports, dead code)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,11 +74,9 @@ min_confidence = 100
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "ignore::UserWarning:torchquad.integration.utils:256",                                       # Our own deprecation warning
-    "ignore:torch.meshgrid:UserWarning",                                                         # PyTorch meshgrid warning 
+    "ignore:torch.meshgrid:UserWarning",                                                         # PyTorch meshgrid warning
     "ignore:Explicitly requested dtype.*truncated:UserWarning",                                  # JAX dtype warnings
     "ignore:In the next release:UserWarning",                                                    # TensorFlow warnings
-    "ignore:DEPRECATION WARNING.*In future versions of torchquad:UserWarning",                   # Our deprecation warnings in TF autograph
     "ignore:integration_domain should be a list:RuntimeWarning",                                 # Intentional warning for conflicting backend arguments
     "ignore:To copy construct from a tensor.*recommended to use sourceTensor.clone:UserWarning", # PyTorch tensor copy warnings
     "ignore:Cannot update the VEGASMap.*integrand which evaluates to zero:RuntimeWarning",       # VEGAS warning for zero integrands

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -1,0 +1,57 @@
+"""Regression tests for loguru library hygiene (issue #184).
+
+torchquad must not reconfigure loguru at import time or wipe a host
+application's log handlers when the user sets the torchquad log level.
+"""
+
+import io
+
+from loguru import logger
+
+from torchquad import MonteCarlo, set_log_level
+
+
+def test_set_log_level_preserves_host_handlers():
+    """set_log_level must not remove handlers registered by the host application.
+
+    Previously set_log_level called logger.remove() with no argument, which
+    removed every sink including the host's (issue #184).
+    """
+    host_sink = io.StringIO()
+    host_handler_id = logger.add(host_sink, level="INFO", filter=lambda record: True)
+    try:
+        set_log_level("WARNING")
+        logger.info("message from the host application")
+        assert "message from the host application" in host_sink.getvalue(), (
+            "set_log_level removed the host application's loguru handler"
+        )
+    finally:
+        logger.remove(host_handler_id)
+        # Remove the handlers set_log_level added and restore the library default
+        # so this test does not leak an enabled state or stderr sink into later tests.
+        import torchquad.utils.set_log_level as set_log_level_module
+
+        for handler_id in set_log_level_module._torchquad_handler_ids:
+            logger.remove(handler_id)
+        set_log_level_module._torchquad_handler_ids.clear()
+        logger.disable("torchquad")
+
+
+def test_torchquad_records_disabled_by_default():
+    """Importing torchquad disables its own loguru records, so running an
+    integration must not leak torchquad log output into a host handler."""
+    # Assert the library default explicitly for order-independence (other tests
+    # may have called set_log_level, which enables torchquad's records).
+    logger.disable("torchquad")
+    host_sink = io.StringIO()
+    host_handler_id = logger.add(host_sink, level="DEBUG", filter=lambda record: True)
+    try:
+        MonteCarlo().integrate(
+            lambda x: x, dim=1, N=100, integration_domain=[[0.0, 1.0]], backend="numpy"
+        )
+        assert "Computed integral" not in host_sink.getvalue(), (
+            "torchquad emitted log records into the host handler while disabled"
+        )
+    finally:
+        logger.remove(host_handler_id)
+        logger.disable("torchquad")

--- a/tests/utils_integration_test.py
+++ b/tests/utils_integration_test.py
@@ -9,6 +9,7 @@ from torchquad.integration.utils import (
     _add_at_indices,
     _setup_integration_domain,
     _is_compiling,
+    expand_func_values_and_squeeze_integral,
 )
 from torchquad.utils.set_precision import set_precision
 from torchquad.utils.enable_cuda import enable_cuda
@@ -217,6 +218,33 @@ def test_is_compiling():
     _run_tests_with_all_backends(_run_is_compiling_tests)
 
 
+def test_expand_func_values_and_squeeze_integral_kwargs():
+    """Regression test for #203: the decorator must handle function_values whether
+    it is passed positionally or as a keyword argument, and must no longer emit the
+    removed (N,)->(N,1) deprecation warning."""
+
+    @expand_func_values_and_squeeze_integral
+    def identity(self, function_values, integration_domain):
+        # Assert the decorator expanded the 1D input to a trailing integrand dim
+        assert function_values.shape[1] == 1
+        return function_values
+
+    class _Dummy:
+        pass
+
+    values_1d = anp.array([1.0, 2.0, 3.0], like="numpy")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning (e.g. the old deprecation) fails the test
+        result_positional = identity(_Dummy(), values_1d, None)
+        result_keyword = identity(_Dummy(), function_values=values_1d, integration_domain=None)
+
+    # The squeeze restores the original 1D shape in both cases
+    assert result_positional.shape == (3,)
+    assert result_keyword.shape == (3,)
+    assert anp.max(anp.abs(result_positional - result_keyword)) == 0.0
+
+
 if __name__ == "__main__":
     try:
         # used to run this test individually
@@ -224,5 +252,6 @@ if __name__ == "__main__":
         test_add_at_indices()
         test_setup_integration_domain()
         test_is_compiling()
+        test_expand_func_values_and_squeeze_integral_kwargs()
     except KeyboardInterrupt:
         pass

--- a/torchquad/__init__.py
+++ b/torchquad/__init__.py
@@ -1,6 +1,13 @@
 import os
 
+from loguru import logger
+
 __version__ = "0.5.0"
+
+# Disable torchquad's own log records by default so importing the library never
+# adds output to a host application's loguru configuration (issue #184).
+# set_log_level() re-enables them when the user opts into logging.
+logger.disable("torchquad")
 
 # Set for release builds
 TORCHQUAD_DISABLE_LOGGING = True
@@ -48,7 +55,5 @@ __all__ = [
 ]
 
 if not TORCHQUAD_DISABLE_LOGGING:
-    from loguru import logger
-
     set_log_level(os.environ.get("TORCHQUAD_LOG_LEVEL", "WARNING"))
     logger.info("Initializing torchquad.")

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -3,22 +3,14 @@ Utility functions for the integrator implementations including extensions for
 autoray, which are registered when importing this file
 """
 
-import sys
-from pathlib import Path
-
-# Change the path to import from the parent folder.
-# A relative import currently does not work when executing the tests.
-sys.path.append(str(Path(__file__).absolute().parent.parent))
-
 from autoray import numpy as anp
 from autoray import infer_backend, register_function
 from functools import partial
 from loguru import logger
 import warnings
 
-# from ..utils.set_precision import _get_precision
-from utils.set_precision import _get_precision
-from utils.set_up_backend import _get_default_backend
+from ..utils.set_precision import _get_precision
+from ..utils.set_up_backend import _get_default_backend
 
 
 def _linspace_with_grads(start, stop, N, requires_grad):
@@ -269,9 +261,6 @@ def expand_func_values_and_squeeze_integral(f):
         )
 
         if is_1d:
-            warnings.warn(
-                "DEPRECATION WARNING: In future versions of torchquad, an array-like object will be returned."
-            )
             if len(args) > 1:
                 # Modify positional arguments
                 args = (args[0], anp.expand_dims(function_values, axis=1), *args[2:])

--- a/torchquad/utils/deployment_test.py
+++ b/torchquad/utils/deployment_test.py
@@ -29,9 +29,6 @@ def _deployment_test():
 
     # Suppress common warnings to reduce noise
     warnings.filterwarnings("ignore", message="torch.meshgrid: in an upcoming release")
-    warnings.filterwarnings(
-        "ignore", message="DEPRECATION WARNING: In future versions of torchquad"
-    )
 
     logger.info("####################################")
     logger.info("######## TESTING DEPLOYMENT ########")

--- a/torchquad/utils/set_log_level.py
+++ b/torchquad/utils/set_log_level.py
@@ -1,18 +1,56 @@
-from loguru import logger
+"""Log-level configuration for torchquad.
+
+Follows loguru's best practices for library logging (issue #184):
+
+- torchquad's own records are disabled by default at import (see ``__init__.py``),
+  so importing the library never adds output to a host application's logging.
+- ``set_log_level()`` enables torchquad's records and adds a handler for them,
+  tracking its id so repeated calls remove only torchquad's own handlers and
+  never touch handlers the host application registered.
+- The library never calls a bare ``logger.remove()``. Users can silence torchquad
+  again with ``logger.disable("torchquad")`` and re-enable it with
+  ``logger.enable("torchquad")``.
+"""
+
 import sys
+
+from loguru import logger
+
+# Ids of the handlers torchquad has added. Tracking them lets set_log_level
+# remove only its own handlers when reconfiguring and leave the host
+# application's handlers untouched.
+_torchquad_handler_ids = []
 
 
 def set_log_level(log_level):
-    """Set the log level for the logger.
-    The preset log level when initialising Torchquad is the value of the TORCHQUAD_LOG_LEVEL environment variable, or 'WARNING' if the environment variable is unset.
+    """Set the log level for torchquad's own log records.
+
+    The preset log level when initialising torchquad is the value of the
+    TORCHQUAD_LOG_LEVEL environment variable, or 'WARNING' if it is unset.
 
     Args:
-        log_level (str): The log level to set. Options are 'TRACE','DEBUG', 'INFO', 'SUCCESS', 'WARNING', 'ERROR', 'CRITICAL'
+        log_level (str): The log level to set. Options are 'TRACE', 'DEBUG',
+            'INFO', 'SUCCESS', 'WARNING', 'ERROR', 'CRITICAL'.
     """
-    logger.remove()
-    logger.add(
+    # torchquad's records are disabled by default (see __init__.py); enable them
+    # once the user opts into logging by setting a level.
+    logger.enable("torchquad")
+
+    # Remove only torchquad's previously added handlers, never the host
+    # application's. An id can go stale if the host reset loguru (e.g. a bare
+    # logger.remove()), so tolerate its absence instead of crashing.
+    for handler_id in _torchquad_handler_ids:
+        try:
+            logger.remove(handler_id)
+        except ValueError:
+            pass
+    _torchquad_handler_ids.clear()
+
+    handler_id = logger.add(
         sys.stderr,
         level=log_level,
         format="<green>{time:HH:mm:ss}</green>|TQ-<blue>{level}</blue>| <level>{message}</level>",
+        filter="torchquad",
     )
+    _torchquad_handler_ids.append(handler_id)
     logger.debug(f"Setting LogLevel to {log_level}")


### PR DESCRIPTION
## Summary

Low-risk fixes, each covered by tests:

- **#184** — `set_log_level` no longer calls the argument-less `logger.remove()` that wiped a host application's loguru handlers. Following loguru's library recipe (mirroring how Cutana solves this): `__init__` calls `logger.disable("torchquad")` so importing the library is silent, and `set_log_level` enables torchquad's records and manages only its own tracked, `torchquad`-filtered handlers — never the host's.
- **Imports** — drop the library-side `sys.path.append` hack in `integration/utils.py` (it imported a top-level `utils` module that can shadow a user's package) in favour of proper relative imports.
- **Stale warning** — remove the years-old `(N,)→(N,1)` deprecation warning while keeping the current squeeze behavior; drop the now-dead `filterwarnings` entries and the matching suppression in `deployment_test`.

## Test plan

- [x] New #184 regression test: host loguru handlers survive `set_log_level`; torchquad stays silent by default.
- [x] New #203 regression test: the squeeze decorator handles `function_values` as a keyword arg and emits no warning.
- [x] Full suite: **87 passed** across installed backends.

## Deferred

The dead `torch.set_default_tensor_type` branch cleanup in `set_precision.py` was **dropped from this PR** — it raises a PyTorch-version-floor question (env files, docs) better decided in the packaging PR.

Closes #184
Closes #203

---

Stack tail: A (#232) → B (#233) → **C (this)**. Base is `chore/tooling-modernization` (B).
