### PR TITLE
Modernize CI actions and raise Python/PyTorch floors

### DIFF
--- a/.github/workflows/deploy_to_pypi.yml
+++ b/.github/workflows/deploy_to_pypi.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install build twine

--- a/.github/workflows/deploy_to_test_pypi.yml
+++ b/.github/workflows/deploy_to_test_pypi.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install build twine

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -13,7 +13,7 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:
@@ -21,7 +21,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,11 +36,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
       - name: Search for severe code errors with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Note that torchquad also works on the CPU; however, it is optimized for GPU usag
 
 For a detailed list of required packages and packages for numerical backends,
 please refer to the conda environment files [environment.yml](/environment.yml) and [environment_all_backends.yml](/environment_all_backends.yml).
-torchquad has been tested with JAX 0.2.25, NumPy 1.19.5, PyTorch 1.10.0 and Tensorflow 2.7.0 on Linux; other versions of the backends should work as well but some may require additional setup on other platforms such as Windows.
+torchquad requires Python 3.10 or newer and has been tested with JAX 0.4.17, NumPy 1.19.5, PyTorch 2.1 and TensorFlow 2.18 on Linux; other versions of the backends should work as well but some may require additional setup on other platforms such as Windows.
 
 
 ### Installation
@@ -116,7 +116,7 @@ Alternatively, it is also possible to use
 
 The PyTorch backend with CUDA support can be installed with
    ```sh
-   conda install "cudatoolkit>=11.1" "pytorch>=1.9=*cuda*" -c conda-forge -c pytorch
+   conda install "cudatoolkit>=11.1" "pytorch>=2.1=*cuda*" -c conda-forge -c pytorch
    ```
 
 Note that since PyTorch is not yet on *conda-forge* for Windows, we have explicitly included it here using `-c pytorch`.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Note that torchquad also works on the CPU; however, it is optimized for GPU usag
 
 For a detailed list of required packages and packages for numerical backends,
 please refer to the conda environment files [environment.yml](/environment.yml) and [environment_all_backends.yml](/environment_all_backends.yml).
-torchquad requires Python 3.10 or newer and has been tested with JAX 0.4.17, NumPy 1.19.5, PyTorch 2.1 and TensorFlow 2.18 on Linux; other versions of the backends should work as well but some may require additional setup on other platforms such as Windows.
+torchquad requires Python 3.10 or newer. Its CI suite runs on Python 3.12 with JAX 0.4.35, NumPy 2.3, PyTorch 2.5 and TensorFlow 2.18 on Linux; other versions of the backends should work as well but some may require additional setup on other platforms such as Windows.
 
 
 ### Installation

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -21,7 +21,7 @@ torchquad's GPU support is tested only on NVIDIA cards with CUDA. We are investi
 For a detailed list of required packages and packages for numerical backends,
 please refer to the conda environment files `environment.yml <https://github.com/esa/torchquad/blob/main/environment.yml>`_ and
 `environment_all_backends.yml <https://github.com/esa/torchquad/blob/main/environment_all_backends.yml>`_.
-torchquad requires Python 3.10 or newer and has been tested with JAX 0.4.17, NumPy 1.19.5, PyTorch 2.1 and TensorFlow 2.18; other versions of the backends should work as well.
+torchquad requires Python 3.10 or newer. Its CI suite runs on Python 3.12 with JAX 0.4.35, NumPy 2.3, PyTorch 2.5 and TensorFlow 2.18; other versions of the backends should work as well.
 
 
 Installation

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -21,7 +21,7 @@ torchquad's GPU support is tested only on NVIDIA cards with CUDA. We are investi
 For a detailed list of required packages and packages for numerical backends,
 please refer to the conda environment files `environment.yml <https://github.com/esa/torchquad/blob/main/environment.yml>`_ and
 `environment_all_backends.yml <https://github.com/esa/torchquad/blob/main/environment_all_backends.yml>`_.
-torchquad has been tested with JAX 0.2.25, NumPy 1.19.5, PyTorch 1.10.0 and Tensorflow 2.7.0; other versions of the backends should work as well.
+torchquad requires Python 3.10 or newer and has been tested with JAX 0.4.17, NumPy 1.19.5, PyTorch 2.1 and TensorFlow 2.18; other versions of the backends should work as well.
 
 
 Installation
@@ -44,7 +44,7 @@ The PyTorch backend with CUDA support can be installed with
 
    .. code-block:: bash
 
-      conda install "cudatoolkit>=11.1" "pytorch>=1.9=*cuda*" -c conda-forge -c pytorch
+      conda install "cudatoolkit>=11.1" "pytorch>=2.1=*cuda*" -c conda-forge -c pytorch
 
 Note that since PyTorch is not yet on *conda-forge* for Windows, we have
 explicitly included it here using ``-c pytorch``.

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - loguru>=0.5.3
   - matplotlib>=3.3.3
   - pytest>=6.2.1
-  - python>=3.8
+  - python>=3.10
   - scipy>=1.6.0
   - sphinx>=3.4.3
   - sphinx_rtd_theme>=0.5.1

--- a/environment_all_backends.yml
+++ b/environment_all_backends.yml
@@ -15,7 +15,7 @@ dependencies:
   # Numerical backend installations with CUDA support where possible:
   - numpy>=1.19.5
   - cudatoolkit>=11.1
-  - pytorch>=1.9 # CPU version
+  - pytorch>=2.1 # CPU version
   # jaxlib with CUDA support is not available for conda
   - pip:
       - --find-links https://storage.googleapis.com/jax-releases/jax_releases.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "torchquad"
 version = "0.5.0"
 description = "Package providing numerical integration methods for PyTorch, jax, TensorFlow and numpy."
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.8, <4"
+requires-python = ">=3.10, <4"
 license = { text = "GPL-3.0" }
 authors = [
     { name = "ESA Advanced Concepts Team", email = "pablo.gomez@esa.int" },
@@ -18,7 +18,9 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Mathematics",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "loguru>=0.5.3",

--- a/torchquad/utils/set_precision.py
+++ b/torchquad/utils/set_precision.py
@@ -40,34 +40,17 @@ def set_precision(data_type="float32", backend="torch"):
     if backend == "torch":
         import torch
 
-        # Use new PyTorch 2.1+ API if available, fallback to legacy for older versions
-        if hasattr(torch, "set_default_dtype"):
-            # Modern PyTorch 2.1+ approach
-            dtype_map = {"float32": torch.float32, "float64": torch.float64}
-            torch.set_default_dtype(dtype_map[data_type])
+        dtype_map = {"float32": torch.float32, "float64": torch.float64}
+        torch.set_default_dtype(dtype_map[data_type])
 
-            # Only set default device to CUDA if CUDA was already initialized
-            # (matching the old behavior more closely)
-            cuda_enabled = torch.cuda.is_initialized()
-            if cuda_enabled:
-                torch.set_default_device("cuda")
-                logger.info(f"Setting Torch's default dtype to {data_type} and device to CUDA.")
-            else:
-                logger.info(f"Setting Torch's default dtype to {data_type} (CPU).")
+        # set_default_device changes only where new tensors are allocated; switch
+        # to CUDA solely when enable_cuda already initialized it, so importing
+        # torchquad never forces a device onto a CPU-only user.
+        if torch.cuda.is_initialized():
+            torch.set_default_device("cuda")
+            logger.info(f"Setting Torch's default dtype to {data_type} and device to CUDA.")
         else:
-            # Legacy approach for older PyTorch versions
-            cuda_enabled = torch.cuda.is_initialized()
-            tensor_dtype, tensor_dtype_name = {
-                ("float32", True): (torch.cuda.FloatTensor, "cuda.Float32"),
-                ("float64", True): (torch.cuda.DoubleTensor, "cuda.Float64"),
-                ("float32", False): (torch.FloatTensor, "Float32"),
-                ("float64", False): (torch.DoubleTensor, "Float64"),
-            }[(data_type, cuda_enabled)]
-            cuda_enabled_info = "CUDA is initialized" if cuda_enabled else "CUDA not initialized"
-            logger.info(
-                f"Setting Torch's default tensor type to {tensor_dtype_name} ({cuda_enabled_info})."
-            )
-            torch.set_default_tensor_type(tensor_dtype)
+            logger.info(f"Setting Torch's default dtype to {data_type} (CPU).")
     elif backend == "jax":
         from jax import config
 


### PR DESCRIPTION
## What & why

Packaging and CI modernization for the 0.6 line (PR D of the 0.6 batch).

- **CI actions:** bump the `run_tests` build job and the paper/deploy workflows off deprecated action versions (`checkout@v2/v3`, `setup-python@v2/v4`, `upload-artifact@v1`). `upload-artifact@v1` now hard-fails on GitHub runners, so `draft-pdf` was broken whenever it fired.
- **Version floors:** raise the Python floor to `>=3.10` (classifiers refreshed to 3.10–3.12) and the PyTorch floor to `>=2.1`. With only PyTorch 2.1+ supported, the dead `set_default_tensor_type` legacy branch in `set_precision` is removed — the modern `set_default_dtype` / `set_default_device` path is always taken.
- **Docs:** refresh the "tested with" backend versions in the README and install guide to match the CI environment.

## Test plan

- [x] `ruff format --check .`, `ruff check .`, `pydoclint torchquad/`, `vulture ... --min-confidence 100` all pass
- [x] Full `pytest` sweep across all four backends — 87 passed
- [x] CI green on this PR

Part of the 0.6 release work.
