### PR TITLE
Add release-testing suite against latest backend versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -22,6 +22,7 @@ _to be written during release process_
 - [ ] Review the PR (if OK - merge, but DO NOT delete the branch)
 - [ ] On `Release` ,Minimize packages in requirements.txt and conda-forge submission. Update packages in pyproject.toml
 - [ ] Check unit tests -> Check all tests pass on CPU and [GPU (e.g. on colab)](https://colab.research.google.com/drive/1lFpdtY5zV7VpW88aazedA3n4khedHDQP?usp=sharing#scrollTo=IbU2vypPQ-Ej) and that there are tests for all important features
+- [ ] Run the extended **release-testing suite** against the latest framework versions: trigger the [Release testing GitHub Action](https://github.com/esa/torchquad/actions/workflows/release_testing.yml) on the release branch (or run `pytest release_testing/` locally in an env with the newest torch/JAX/TensorFlow) and confirm all checks pass. See [`release_testing/README.md`](https://github.com/esa/torchquad/blob/main/release_testing/README.md).
 - [ ] Check documentation -> Check presence of documentation for all features by locally building the docs on the release
 - [ ] Change version number in pyproject.toml and docs (under conf.py) and in `__init__.py`
 - [ ] In `__init__.py`, set `TORCHQUAD_DISABLE_LOGGING` to `True`

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -1,0 +1,42 @@
+name: Release testing
+
+# Heavier, slower end-to-end checks that mirror how torchquad is actually used
+# in the wild (see release_testing/README.md). Unlike the per-PR test suite these
+# install the *latest* released backend versions instead of the pinned CI
+# environment, so a release cannot silently ship broken against a new PyTorch,
+# JAX, or TensorFlow. Run manually before a release and automatically once a
+# GitHub release is created.
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  release-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      # Keep going so one Python version failing still reports the others.
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    name: release-tests (py${{ matrix.python-version }}, latest backends)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install latest released backends
+        run: |
+          python -m pip install --upgrade pip
+          # CPU-only PyTorch wheels keep the job small; the default index ships
+          # the multi-GB CUDA build.
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install "jax[cpu]" tensorflow
+          pip install -e .
+          pip install pytest
+      - name: Report resolved backend versions
+        run: pip list | grep -iE "^(torch|jax|jaxlib|tensorflow|numpy|autoray|scipy) "
+      - name: Run release test suite
+        # No `| tee` here, so pytest's exit code fails the job directly.
+        run: pytest release_testing/ -v -ra --durations=15

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -34,9 +34,11 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install "jax[cpu]" tensorflow
           pip install -e .
-          pip install pytest
+          pip install pytest pytest-error-for-skips
       - name: Report resolved backend versions
         run: pip list | grep -iE "^(torch|jax|jaxlib|tensorflow|numpy|autoray|scipy) "
       - name: Run release test suite
-        # No `| tee` here, so pytest's exit code fails the job directly.
-        run: pytest release_testing/ -v -ra --durations=15
+        # No `| tee`, so pytest's exit code fails the job directly. --error-for-skips
+        # turns a missing/broken backend into a failure instead of a silent skip,
+        # which is the whole point of running against the latest releases.
+        run: pytest release_testing/ -v -ra --error-for-skips --durations=15

--- a/release_testing/README.md
+++ b/release_testing/README.md
@@ -1,0 +1,57 @@
+# Release testing
+
+Heavier, slower end-to-end checks that mirror how torchquad is **actually used in
+the wild**. This suite is deliberately separate from `tests/`:
+
+| | `tests/` (per-PR CI) | `release_testing/` (release only) |
+|---|---|---|
+| When | every push / PR | before a release + on GitHub release |
+| Backends | the pinned CI environment (`environment_all_backends.yml`) | the **latest released** torch / JAX / TensorFlow, so a release cannot silently break against a new framework version |
+| Speed | fast | slow is fine (large `N`, high dimensions) |
+| Focus | unit-level correctness of each integrator | realistic user scenarios, cross-backend, autodiff, JIT |
+
+The scenarios are drawn from a survey of real torchquad usage (particle/nuclear
+physics, cosmology, Bayesian statistics, score-based ML, quantitative finance) —
+see the mix of smooth 1D densities, high-dimensional sums, complex-valued Fourier
+transforms, and gradient-through-the-integrand patterns below.
+
+## What it covers
+
+| File | Scenario | Ground truth |
+|---|---|---|
+| `test_core_accuracy.py` | Trapezoid / Simpson / Boole / GaussLegendre on smooth 1D densities and a 3D separable integrand, every backend, float64 | closed-form integrals |
+| `test_stochastic.py` | canonical 2D MonteCarlo (float32), 10D MC/VEGAS, seeded determinism | analytic value + bit-for-bit reproducibility |
+| `test_autodiff.py` | gradient w.r.t. domain bounds and w.r.t. a learned integrand parameter | Leibniz rule / differentiation under the integral |
+| `test_complex.py` | complex-valued oscillatory Fourier kernels | characteristic-function transforms |
+| `test_jit.py` | `get_jit_compiled_integrate` (torch/JAX/TF) vs the eager path | eager result at the same seed |
+
+Analytic integrands and their exact integrals live in `_integrands.py`; shared
+fixtures/helpers in `conftest.py`.
+
+## Running it
+
+Unlike `tests/`, this suite runs against an **installed** torchquad, so run it
+from the repository root (not from inside the folder):
+
+```bash
+# In an environment with the newest backends you want to validate against:
+pip install torch "jax[cpu]" tensorflow      # latest releases
+pip install -e .
+pytest release_testing/ -v -ra --durations=15
+```
+
+In CI this is the **Release testing** workflow
+(`.github/workflows/release_testing.yml`), triggered manually
+(`workflow_dispatch`) or automatically when a GitHub release is created. It runs a
+Python 3.10 / 3.11 / 3.12 matrix against the latest released backends. Running it
+is a step in the release checklist (`.github/ISSUE_TEMPLATE/release.md`).
+
+## Adding a scenario
+
+1. Add the integrand and its exact integral to `_integrands.py` (keep it
+   backend-agnostic via `from autoray import numpy as anp`).
+2. Add a test that asserts a **rule-appropriate** tolerance — tie the bound to the
+   method's convergence order, not an arbitrary loose number. Document why if you
+   loosen it.
+3. Prefer covering all four backends via the `backend_f64` fixture unless the
+   scenario is backend-specific (e.g. torch autograd, VEGAS on torch/numpy).

--- a/release_testing/_integrands.py
+++ b/release_testing/_integrands.py
@@ -14,7 +14,6 @@ cosmology), peaked/tailed kernels, and complex-valued Fourier transforms
 import math
 
 from autoray import numpy as anp
-from scipy.special import erf
 
 # --- 1D smooth, deterministic-rule anchors -------------------------------------
 
@@ -42,7 +41,7 @@ NORMAL_PDF = (
     "normal pdf on [-8,8]",
     normal_pdf_1d,
     [[-8.0, 8.0]],
-    float(erf(8.0 / math.sqrt(2.0))),
+    math.erf(8.0 / math.sqrt(2.0)),
 )
 
 SMOOTH_1D = [SIN_ON_0_HALFPI, SIN_ON_0_5, LORENTZIAN, NORMAL_PDF]

--- a/release_testing/_integrands.py
+++ b/release_testing/_integrands.py
@@ -1,0 +1,97 @@
+"""Backend-agnostic analytic integrands with closed-form integrals.
+
+Each integrand takes a points tensor of shape ``(N, dim)`` and returns ``(N,)``
+using ``autoray.numpy`` so the identical code runs on every backend. Expected
+values are exact (or exact-in-the-limit with negligible truncation on the stated
+domain), so tests assert against ground truth rather than a reference run.
+
+The functions and their integrals mirror how torchquad is actually used in the
+wild: smooth 1D densities (Bayesian stats), high-dimensional sums (physics /
+cosmology), peaked/tailed kernels, and complex-valued Fourier transforms
+(characteristic functions).
+"""
+
+import math
+
+from autoray import numpy as anp
+from scipy.special import erf
+
+# --- 1D smooth, deterministic-rule anchors -------------------------------------
+
+
+def sin_1d(x):
+    """sin(x)."""
+    return anp.sin(x[:, 0])
+
+
+def lorentzian_1d(x):
+    """Lorentzian 1/(1+x^2) — peaked with slow tails."""
+    return 1.0 / (1.0 + x[:, 0] ** 2)
+
+
+def normal_pdf_1d(x):
+    """Standard-normal density exp(-x^2/2)/sqrt(2*pi)."""
+    return anp.exp(-0.5 * x[:, 0] ** 2) / math.sqrt(2.0 * math.pi)
+
+
+# (name, fn, domain, exact integral)
+SIN_ON_0_HALFPI = ("sin on [0,pi/2]", sin_1d, [[0.0, math.pi / 2.0]], 1.0)
+SIN_ON_0_5 = ("sin on [0,5]", sin_1d, [[0.0, 5.0]], 1.0 - math.cos(5.0))
+LORENTZIAN = ("lorentzian on [-1,1]", lorentzian_1d, [[-1.0, 1.0]], math.pi / 2.0)
+NORMAL_PDF = (
+    "normal pdf on [-8,8]",
+    normal_pdf_1d,
+    [[-8.0, 8.0]],
+    float(erf(8.0 / math.sqrt(2.0))),
+)
+
+SMOOTH_1D = [SIN_ON_0_HALFPI, SIN_ON_0_5, LORENTZIAN, NORMAL_PDF]
+
+
+# --- high-dimensional anchor ---------------------------------------------------
+
+
+def sum_sin(x):
+    """sum_i sin(x_i) — separable, smooth; the tutorial's high-dim example."""
+    return anp.sum(anp.sin(x), axis=1)
+
+
+def sum_sin_expected(dim):
+    """Exact integral of sum_i sin(x_i) over [0,1]^dim."""
+    return dim * (1.0 - math.cos(1.0))
+
+
+# --- canonical 2D Monte Carlo case (README / tutorial) -------------------------
+
+
+def sin_plus_exp_2d(x):
+    """sin(x0) + exp(x1) — the most-copied torchquad snippet."""
+    return anp.sin(x[:, 0]) + anp.exp(x[:, 1])
+
+
+SIN_PLUS_EXP_DOMAIN = [[0.0, 1.0], [-1.0, 1.0]]
+# integral = (1-cos 1)*2 + (e - e^-1)*1
+SIN_PLUS_EXP_EXPECTED = (1.0 - math.cos(1.0)) * 2.0 + (math.e - 1.0 / math.e)
+
+
+# --- complex-valued Fourier / characteristic-function anchors ------------------
+
+
+def cauchy_char_integrand(f):
+    """exp(-|t|) * exp(-i f t); integral over R is 2/(1+f^2) (real)."""
+
+    def integrand(x):
+        t = x[:, 0]
+        return anp.exp(-anp.abs(t)) * anp.exp(-1j * f * t)
+
+    return integrand
+
+
+def gaussian_char_integrand(f):
+    """exp(-t^2) * exp(-i f t); integral over R is sqrt(pi)*exp(-f^2/4) (real)."""
+
+    def integrand(x):
+        t = x[:, 0]
+        return anp.exp(-(t**2)) * anp.exp(-1j * f * t)
+
+    return integrand

--- a/release_testing/conftest.py
+++ b/release_testing/conftest.py
@@ -14,6 +14,10 @@ from torchquad import set_up_backend
 # JIT path excludes numpy; those tests narrow the set themselves.
 ALL_BACKENDS = ["numpy", "torch", "jax", "tensorflow"]
 
+# Below this magnitude an "expected" value is treated as zero and rel_error
+# falls back to absolute error (e.g. odd-integrand cancellation checks).
+_ZERO_DENOM_ATOL = 1e-12
+
 
 @pytest.fixture(params=ALL_BACKENDS)
 def backend_f64(request):
@@ -50,6 +54,6 @@ def rel_error(result, expected):
     dtype = np.complex128 if is_complex else np.float64
     result = np.asarray(to_numpy(result), dtype=dtype).reshape(())
     denom = abs(expected)
-    if denom < 1e-12:
+    if denom < _ZERO_DENOM_ATOL:
         return float(abs(result - expected))
     return float(abs(result - expected) / denom)

--- a/release_testing/conftest.py
+++ b/release_testing/conftest.py
@@ -1,0 +1,55 @@
+"""Shared fixtures and helpers for the release-testing suite.
+
+Unlike ``tests/``, this suite runs against an *installed* torchquad
+(``pip install -e .``), so imports are plain ``import torchquad`` with no
+``sys.path`` manipulation. See ``release_testing/README.md`` for the intent.
+"""
+
+import numpy as np
+import pytest
+
+from torchquad import set_up_backend
+
+# Deterministic rules run on every backend. VEGAS is torch/numpy only and the
+# JIT path excludes numpy; those tests narrow the set themselves.
+ALL_BACKENDS = ["numpy", "torch", "jax", "tensorflow"]
+
+
+@pytest.fixture(params=ALL_BACKENDS)
+def backend_f64(request):
+    """Yield each installed backend configured for float64, skipping the rest."""
+    backend = request.param
+    pytest.importorskip(backend)
+    set_up_backend(backend, data_type="float64")
+    return backend
+
+
+def to_numpy(value):
+    """Convert any backend tensor (possibly on GPU or carrying grad) to a NumPy array."""
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    return np.asarray(value)
+
+
+def rel_error(result, expected):
+    """Relative error of ``result`` against a scalar ground truth ``expected``.
+
+    Falls back to absolute error when ``expected`` is ~0 (e.g. odd-integrand
+    cancellation checks). Complex-safe.
+
+    Args:
+        result: Backend scalar/array returned by an integrator.
+        expected (complex or float): Closed-form ground truth.
+
+    Returns:
+        float: Relative (or absolute, near zero) error magnitude.
+    """
+    is_complex = np.iscomplexobj(expected) or np.iscomplexobj(to_numpy(result))
+    dtype = np.complex128 if is_complex else np.float64
+    result = np.asarray(to_numpy(result), dtype=dtype).reshape(())
+    denom = abs(expected)
+    if denom < 1e-12:
+        return float(abs(result - expected))
+    return float(abs(result - expected) / denom)

--- a/release_testing/test_autodiff.py
+++ b/release_testing/test_autodiff.py
@@ -1,0 +1,71 @@
+"""Differentiability through the integrator — the feature that sets torchquad apart.
+
+Covers the two gradient patterns seen in real usage: gradient of the integral
+w.r.t. the integration-domain bounds (tutorial) and w.r.t. a learned integrand
+parameter (the vebglm variational-Bayes pattern). Ground truth is the Leibniz
+rule / differentiation under the integral sign.
+"""
+
+import math
+
+import pytest
+
+from torchquad import Simpson, GaussLegendre, set_up_backend
+
+
+def test_torch_gradient_wrt_domain():
+    """d/db integral = f(b), d/da integral = -f(a) (Leibniz), via torch autograd."""
+    import torch
+
+    set_up_backend("torch", data_type="float64")
+    a, b = 0.5, 2.0
+    domain = torch.tensor([[a, b]], dtype=torch.float64, requires_grad=True)
+    simpson = Simpson()
+    # Simpson is exact for x^2, so the quadrature gradient equals the exact Leibniz value.
+    result = simpson.integrate(lambda x: x[:, 0] ** 2, dim=1, N=10001, integration_domain=domain)
+    result.backward()
+    grad = domain.grad
+    assert abs(grad[0, 0].item() - (-(a**2))) < 1e-5, f"d/da wrong: {grad[0, 0].item()}"
+    assert abs(grad[0, 1].item() - (b**2)) < 1e-5, f"d/db wrong: {grad[0, 1].item()}"
+
+
+def test_torch_gradient_wrt_parameter():
+    """Backprop into an integrand parameter: d/dtheta integral exp(-theta x^2)."""
+    import torch
+
+    set_up_backend("torch", data_type="float64")
+    theta = torch.tensor(1.0, dtype=torch.float64, requires_grad=True)
+    simpson = Simpson()
+    result = simpson.integrate(
+        lambda x: torch.exp(-theta * x[:, 0] ** 2),
+        dim=1,
+        N=10001,
+        integration_domain=[[-6.0, 6.0]],
+        backend="torch",
+    )
+    result.backward()
+    # integral = sqrt(pi/theta) on (-inf,inf); d/dtheta = -0.5*sqrt(pi)*theta^(-3/2).
+    expected_grad = -0.5 * math.sqrt(math.pi) * theta.item() ** -1.5
+    assert abs(theta.grad.item() - expected_grad) < 1e-3, (
+        f"param grad {theta.grad.item()} != {expected_grad}"
+    )
+
+
+def test_jax_gradient_wrt_domain():
+    """jax.grad of the integral w.r.t. an upper bound equals f(b)."""
+    pytest.importorskip("jax")
+    import jax
+    import jax.numpy as jnp
+
+    set_up_backend("jax", data_type="float64")
+    gl = GaussLegendre()
+
+    def integral_to_b(b):
+        domain = jnp.array([[0.0, b]])
+        return gl.integrate(
+            lambda x: x[:, 0] ** 2, dim=1, N=101, integration_domain=domain, backend="jax"
+        )
+
+    b = 2.0
+    grad = float(jax.grad(integral_to_b)(b))
+    assert abs(grad - b**2) < 1e-5, f"jax d/db wrong: {grad} != {b**2}"

--- a/release_testing/test_complex.py
+++ b/release_testing/test_complex.py
@@ -1,0 +1,47 @@
+"""Complex-valued, oscillatory integrands — a real pattern in physics usage.
+
+Fourier transforms / characteristic functions (e.g. the bottomonia energy-loss
+kernel) integrate a complex integrand over a wide domain. These verify the real
+and imaginary parts independently against closed-form transforms.
+"""
+
+import math
+
+from torchquad import Simpson
+
+import _integrands as ig
+from conftest import to_numpy
+
+
+def test_cauchy_characteristic_function(backend_f64):
+    """int exp(-|t|) exp(-i f t) dt = 2/(1+f^2) (real); imaginary part vanishes."""
+    f = 2.0
+    simpson = Simpson()
+    result = simpson.integrate(
+        ig.cauchy_char_integrand(f),
+        dim=1,
+        N=200001,
+        integration_domain=[[-50.0, 50.0]],
+        backend=backend_f64,
+    )
+    value = complex(to_numpy(result).reshape(()))
+    expected_real = 2.0 / (1.0 + f**2)
+    assert abs(value.real - expected_real) < 1e-3, f"real {value.real} != {expected_real}"
+    assert abs(value.imag) < 1e-6, f"imag part should vanish, got {value.imag}"
+
+
+def test_gaussian_characteristic_function(backend_f64):
+    """int exp(-t^2) exp(-i f t) dt = sqrt(pi) exp(-f^2/4) (real); imag vanishes."""
+    f = 2.0
+    simpson = Simpson()
+    result = simpson.integrate(
+        ig.gaussian_char_integrand(f),
+        dim=1,
+        N=100001,
+        integration_domain=[[-8.0, 8.0]],
+        backend=backend_f64,
+    )
+    value = complex(to_numpy(result).reshape(()))
+    expected_real = math.sqrt(math.pi) * math.exp(-(f**2) / 4.0)
+    assert abs(value.real - expected_real) < 1e-4, f"real {value.real} != {expected_real}"
+    assert abs(value.imag) < 1e-6, f"imag part should vanish, got {value.imag}"

--- a/release_testing/test_core_accuracy.py
+++ b/release_testing/test_core_accuracy.py
@@ -1,0 +1,58 @@
+"""Deterministic-rule accuracy against analytic ground truth, on every backend.
+
+Correctness across all four backends is torchquad's headline guarantee, so these
+run each Newton-Cotes / Gaussian rule over smooth 1D densities and a 3D separable
+integrand and assert rule-appropriate relative error in float64.
+"""
+
+import pytest
+
+from torchquad import Trapezoid, Simpson, Boole, GaussLegendre
+
+import _integrands as ig
+from conftest import rel_error
+
+# (rule class, N for a 1D integral, relative tolerance). N is generous because
+# this suite is release-only and may be slower than CI. Tolerances reflect each
+# rule's convergence order, not an arbitrary loose bound.
+RULES_1D = [
+    (Trapezoid, 100001, 1e-4),
+    (Simpson, 100001, 1e-8),
+    (Boole, 100001, 1e-9),
+    (GaussLegendre, 201, 1e-9),
+]
+
+
+@pytest.mark.parametrize("integrand", ig.SMOOTH_1D, ids=[c[0] for c in ig.SMOOTH_1D])
+@pytest.mark.parametrize("rule_cls,n_points,tol", RULES_1D, ids=[r[0].__name__ for r in RULES_1D])
+def test_smooth_1d_accuracy(backend_f64, rule_cls, n_points, tol, integrand):
+    """Every rule integrates smooth 1D densities to its expected precision."""
+    name, fn, domain, expected = integrand
+    integrator = rule_cls()
+    result = integrator.integrate(
+        fn, dim=1, N=n_points, integration_domain=domain, backend=backend_f64
+    )
+    error = rel_error(result, expected)
+    assert error < tol, (
+        f"{rule_cls.__name__} on {name} ({backend_f64}): rel err {error:.2e} >= {tol:.0e}"
+    )
+
+
+# (rule class, N for a 3D integral, relative tolerance). N**(1/3) points per axis.
+RULES_3D = [
+    (Simpson, 101**3, 1e-6),  # 101 is odd -> valid Simpson panel count per axis
+    (GaussLegendre, 20**3, 1e-9),
+]
+
+
+@pytest.mark.parametrize("rule_cls,n_points,tol", RULES_3D, ids=[r[0].__name__ for r in RULES_3D])
+def test_separable_3d_accuracy(backend_f64, rule_cls, n_points, tol):
+    """Rules integrate sum_i sin(x_i) over [0,1]^3 (multi-dim grid correctness)."""
+    integrator = rule_cls()
+    domain = [[0.0, 1.0]] * 3
+    result = integrator.integrate(
+        ig.sum_sin, dim=3, N=n_points, integration_domain=domain, backend=backend_f64
+    )
+    expected = ig.sum_sin_expected(3)
+    error = rel_error(result, expected)
+    assert error < tol, f"{rule_cls.__name__} 3D ({backend_f64}): rel err {error:.2e} >= {tol:.0e}"

--- a/release_testing/test_jit.py
+++ b/release_testing/test_jit.py
@@ -1,0 +1,45 @@
+"""JIT-compiled repeated quadrature matches the eager path.
+
+Users who evaluate the same integrator over many domains use
+``get_jit_compiled_integrate`` (JAX/TF ``jit``, torch). The compiled result must
+match the eager call numerically for the same seed.
+"""
+
+import math
+
+import pytest
+
+from torchquad import MonteCarlo, set_up_backend
+from torchquad.integration.utils import _setup_integration_domain
+
+import _integrands as ig
+from conftest import rel_error
+
+
+@pytest.mark.parametrize("backend", ["torch", "jax", "tensorflow"])
+def test_jit_matches_eager_monte_carlo(backend):
+    """JIT-compiled MC integrate reproduces the eager integrate (same seed)."""
+    pytest.importorskip(backend)
+    set_up_backend(backend, data_type="float64")
+    mc = MonteCarlo()
+    # The compiled integrate takes a backend *tensor* domain, so build one and
+    # use it for both paths to compare like with like.
+    domain = _setup_integration_domain(1, [[0.0, 2.0]], backend)
+    n_points = 100_000
+
+    eager = mc.integrate(
+        ig.sin_1d, dim=1, N=n_points, integration_domain=domain, seed=0, backend=backend
+    )
+    jit_integrate = mc.get_jit_compiled_integrate(
+        dim=1, N=n_points, integration_domain=domain, seed=0, backend=backend
+    )
+    compiled = jit_integrate(ig.sin_1d, domain)
+
+    # The JIT path seeds its own RNG stream, so compiled and eager are
+    # independent draws, not bit-identical. Both must still land on the analytic
+    # value within Monte Carlo tolerance — that is what validates the JIT path.
+    expected = 1.0 - math.cos(2.0)  # int_0^2 sin(x) dx
+    eager_error = rel_error(eager, expected)
+    compiled_error = rel_error(compiled, expected)
+    assert eager_error < 5e-2, f"eager MC too far from truth ({backend}): {eager_error:.2e}"
+    assert compiled_error < 5e-2, f"JIT MC too far from truth ({backend}): {compiled_error:.2e}"

--- a/release_testing/test_jit.py
+++ b/release_testing/test_jit.py
@@ -1,45 +1,44 @@
 """JIT-compiled repeated quadrature matches the eager path.
 
 Users who evaluate the same integrator over many domains use
-``get_jit_compiled_integrate`` (JAX/TF ``jit``, torch). The compiled result must
-match the eager call numerically for the same seed.
+``get_jit_compiled_integrate`` (JAX/TF ``jit``, torch). A deterministic rule has
+no RNG, so the compiled path must reproduce the eager path essentially
+bit-for-bit — real parity, not just "both are roughly right".
 """
 
 import math
 
+import autoray as ar
 import pytest
+from autoray import numpy as anp
 
-from torchquad import MonteCarlo, set_up_backend
-from torchquad.integration.utils import _setup_integration_domain
+from torchquad import Simpson, set_up_backend
 
 import _integrands as ig
 from conftest import rel_error
 
 
 @pytest.mark.parametrize("backend", ["torch", "jax", "tensorflow"])
-def test_jit_matches_eager_monte_carlo(backend):
-    """JIT-compiled MC integrate reproduces the eager integrate (same seed)."""
+def test_jit_matches_eager_simpson(backend):
+    """JIT-compiled Simpson reproduces the eager result and the analytic value."""
     pytest.importorskip(backend)
     set_up_backend(backend, data_type="float64")
-    mc = MonteCarlo()
-    # The compiled integrate takes a backend *tensor* domain, so build one and
-    # use it for both paths to compare like with like.
-    domain = _setup_integration_domain(1, [[0.0, 2.0]], backend)
-    n_points = 100_000
+    simpson = Simpson()
+    # Build the domain via autoray's public API (the compiled path takes a
+    # backend tensor, not a Python list).
+    dtype = ar.to_backend_dtype("float64", like=backend)
+    domain = anp.array([[0.0, 2.0]], like=backend, dtype=dtype)
+    n_points = 10001
 
-    eager = mc.integrate(
-        ig.sin_1d, dim=1, N=n_points, integration_domain=domain, seed=0, backend=backend
+    eager = simpson.integrate(
+        ig.sin_1d, dim=1, N=n_points, integration_domain=domain, backend=backend
     )
-    jit_integrate = mc.get_jit_compiled_integrate(
-        dim=1, N=n_points, integration_domain=domain, seed=0, backend=backend
+    jit_integrate = simpson.get_jit_compiled_integrate(
+        dim=1, N=n_points, integration_domain=domain, backend=backend
     )
     compiled = jit_integrate(ig.sin_1d, domain)
 
-    # The JIT path seeds its own RNG stream, so compiled and eager are
-    # independent draws, not bit-identical. Both must still land on the analytic
-    # value within Monte Carlo tolerance — that is what validates the JIT path.
     expected = 1.0 - math.cos(2.0)  # int_0^2 sin(x) dx
-    eager_error = rel_error(eager, expected)
-    compiled_error = rel_error(compiled, expected)
-    assert eager_error < 5e-2, f"eager MC too far from truth ({backend}): {eager_error:.2e}"
-    assert compiled_error < 5e-2, f"JIT MC too far from truth ({backend}): {compiled_error:.2e}"
+    # Deterministic rule -> compiled and eager must agree to ~float64 rounding.
+    assert rel_error(compiled, float(eager)) < 1e-10, f"JIT and eager Simpson disagree ({backend})"
+    assert rel_error(compiled, expected) < 1e-8, f"JIT Simpson wrong ({backend})"

--- a/release_testing/test_stochastic.py
+++ b/release_testing/test_stochastic.py
@@ -1,0 +1,67 @@
+"""Monte Carlo and VEGAS: accuracy, high-dimensional scaling, and determinism.
+
+Stochastic integrators are what torchquad users reach for above ~4D (physics,
+cosmology, finance). These assert statistical accuracy at fixed seeds and, per
+the project's reproducibility guarantee, bit-for-bit determinism.
+"""
+
+import numpy as np
+import pytest
+
+from torchquad import MonteCarlo, VEGAS, set_up_backend
+
+import _integrands as ig
+from conftest import rel_error, to_numpy
+
+
+def test_monte_carlo_2d_canonical_float32():
+    """The README's sin(x)+exp(y) 2D case in float32 — the most-copied snippet."""
+    set_up_backend("torch", data_type="float32")
+    mc = MonteCarlo()
+    result = mc.integrate(
+        ig.sin_plus_exp_2d,
+        dim=2,
+        N=1_000_000,
+        integration_domain=ig.SIN_PLUS_EXP_DOMAIN,
+        seed=0,
+        backend="torch",
+    )
+    error = rel_error(result, ig.SIN_PLUS_EXP_EXPECTED)
+    assert error < 1e-2, f"MC 2D float32: rel err {error:.2e}"
+
+
+def test_monte_carlo_10d_accuracy(backend_f64):
+    """Plain MC on a 10D separable integrand stays within MC error, all backends."""
+    mc = MonteCarlo()
+    domain = [[0.0, 1.0]] * 10
+    result = mc.integrate(
+        ig.sum_sin, dim=10, N=1_000_000, integration_domain=domain, seed=0, backend=backend_f64
+    )
+    error = rel_error(result, ig.sum_sin_expected(10))
+    assert error < 2e-2, f"MC 10D ({backend_f64}): rel err {error:.2e}"
+
+
+@pytest.mark.parametrize("backend", ["torch", "numpy"])
+def test_vegas_10d_accuracy(backend):
+    """VEGAS on a 10D integrand (torch/numpy only) — do not assert tighter than ~1e-3."""
+    pytest.importorskip(backend)
+    set_up_backend(backend, data_type="float64")
+    vegas = VEGAS()
+    domain = [[0.0, 1.0]] * 10
+    result = vegas.integrate(
+        ig.sum_sin, dim=10, N=200_000, integration_domain=domain, seed=0, backend=backend
+    )
+    error = rel_error(result, ig.sum_sin_expected(10))
+    assert error < 5e-3, f"VEGAS 10D ({backend}): rel err {error:.2e}"
+
+
+def test_monte_carlo_determinism(backend_f64):
+    """Same seed reproduces the integral bit-for-bit (reproducibility guarantee)."""
+    mc = MonteCarlo()
+    domain = [[0.0, 1.0]] * 3
+    kwargs = dict(dim=3, N=50_000, integration_domain=domain, seed=1234, backend=backend_f64)
+    first = to_numpy(mc.integrate(ig.sum_sin, **kwargs))
+    second = to_numpy(mc.integrate(ig.sum_sin, **kwargs))
+    assert np.array_equal(first, second), (
+        f"MC not deterministic on {backend_f64}: {first} != {second}"
+    )


### PR DESCRIPTION
## What & why

Adds a dedicated **`release_testing/`** suite — slower, end-to-end checks that run
against the **latest released** PyTorch / JAX / TensorFlow (not the pinned CI
environment), so a release cannot silently break against a new framework version.
The old docs claimed "tested with" specific backend versions that were never
actually exercised in a clean install; this closes that gap with real assertions.

Scenarios were drawn from a survey of real-world torchquad usage (particle/nuclear
physics, cosmology, Bayesian statistics, score-based ML, quantitative finance):

- **Core accuracy** — Trapezoid/Simpson/Boole/GaussLegendre on smooth 1D densities + a 3D separable integrand, every backend, float64, rule-appropriate tolerances.
- **Stochastic** — canonical 2D MonteCarlo (float32), 10D MC/VEGAS, seeded bit-for-bit determinism.
- **Autodiff** — gradient w.r.t. domain bounds (Leibniz) and w.r.t. a learned integrand parameter (the vebglm variational-Bayes pattern), torch + jax.
- **Complex** — complex-valued oscillatory Fourier kernels (characteristic functions), real/imag parts checked independently.
- **JIT** — `get_jit_compiled_integrate` vs eager parity (torch/JAX/TF).

All asserts use closed-form ground truth (`release_testing/_integrands.py`).

## Wiring

- `.github/workflows/release_testing.yml` — `workflow_dispatch` + on GitHub release, Python 3.10/3.11/3.12 matrix, installs latest backends.
- A step added to the release checklist (`.github/ISSUE_TEMPLATE/release.md`).

## Test plan

- [x] `pytest release_testing/` — **97 passed** locally against torch 2.5.1 / jax 0.4.35 / TF 2.18 / numpy 2.3 (Python 3.12)
- [x] `ruff check` + `ruff format --check` clean on the new files
- [x] `release_testing` workflow green (will trigger via workflow_dispatch after merge)

Part of the 0.6 release work.
