### PR TITLE
Add packaging extras and modernize install docs (C5-C7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ This is a brief guide for how to set up torchquad.
 
 ### Prerequisites
 
-We recommend using [conda](https://anaconda.org/conda-forge/torchquad), especially if you want to utilize the GPU.
-With PyTorch it will automatically set up CUDA and the cudatoolkit for you, for example.
-Note that torchquad also works on the CPU; however, it is optimized for GPU usage. torchquad's GPU support is tested only on NVIDIA cards with CUDA. We are investigating future support for AMD cards through [ROCm](https://pytorch.org/blog/pytorch-for-amd-rocm-platform-now-available-as-python-package/).
+torchquad has no backend pinned as a hard dependency — install the numerical backend(s) you want (PyTorch, JAX, TensorFlow) alongside it. It also runs on NumPy alone. Any of pip, [uv](https://docs.astral.sh/uv/), or conda works; pick whichever fits your workflow.
+
+Note that torchquad also works on the CPU; however, it is optimized for GPU usage. GPU support is tested only on NVIDIA cards with CUDA. For GPU installs, follow each framework's own install guide — the CPU-only convenience extras below cannot select GPU wheels, and JAX/TensorFlow GPU builds are Linux/WSL2-only.
 
 For a detailed list of required packages and packages for numerical backends,
 please refer to the conda environment files [environment.yml](/environment.yml) and [environment_all_backends.yml](/environment_all_backends.yml).
@@ -104,38 +104,41 @@ torchquad requires Python 3.10 or newer. Its CI suite runs on Python 3.12 with J
 
 ### Installation
 
-The easiest way to install torchquad is simply to
+Install torchquad from PyPI:
+   ```sh
+   pip install torchquad
+   # or, with uv:
+   uv pip install torchquad
+   ```
+
+It is also available on conda-forge:
    ```sh
    conda install torchquad -c conda-forge
    ```
 
-Alternatively, it is also possible to use
+**Adding a backend (CPU).** torchquad ships convenience extras that pull in the
+CPU build of a backend from the default package index:
    ```sh
-   pip install torchquad
+   pip install "torchquad[torch]"        # PyTorch (CPU)
+   pip install "torchquad[jax]"          # JAX (CPU)
+   pip install "torchquad[tensorflow]"   # TensorFlow (CPU)
+   pip install "torchquad[all]"          # all three (CPU)
    ```
 
-The PyTorch backend with CUDA support can be installed with
+**Adding a backend (GPU).** These extras cannot select GPU wheels (a Python
+package cannot encode the CUDA-specific index URLs each framework needs), so for
+GPU support install the backend from its own guide, then `pip install torchquad`:
+   - PyTorch: <https://pytorch.org/get-started/locally/>
+   - JAX (Linux/WSL2 only): <https://docs.jax.dev/en/latest/installation.html>
+   - TensorFlow (Linux/WSL2 only): <https://www.tensorflow.org/install/gpu>
+
+For a full multi-backend setup, the conda file
+[environment_all_backends.yml](/environment_all_backends.yml) installs every
+backend (CPU) in one step:
    ```sh
-   conda install "cudatoolkit>=11.1" "pytorch>=2.1=*cuda*" -c conda-forge -c pytorch
+   conda env create -f environment_all_backends.yml
+   conda activate torchquad
    ```
-
-Note that since PyTorch is not yet on *conda-forge* for Windows, we have explicitly included it here using `-c pytorch`.
-Note also that installing PyTorch with *pip* may **not** set it up with CUDA support. Therefore, we recommend to use *conda*.
-
-Here are installation instructions for other numerical backends:
-   ```sh
-   conda install "tensorflow>=2.6.0=cuda*" -c conda-forge
-   pip install "jax[cuda]>=0.4.17" --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html # linux only
-   conda install "numpy>=1.19.5" -c conda-forge
-   ```
-
-More installation instructions for numerical backends can be found in
-[environment_all_backends.yml](/environment_all_backends.yml) and at the
-backend documentations, for example
-https://pytorch.org/get-started/locally/,
-https://github.com/google/jax/#installation and
-https://www.tensorflow.org/install/gpu, and often there are multiple ways to
-install them.
 
 
 ### Test
@@ -349,7 +352,7 @@ Distributed under the GPL-3.0 License. See [LICENSE](https://github.com/esa/torc
 <!-- FAQ -->
 ## FAQ
 
-  1. Q: `Error enabling CUDA. cuda.is_available() returned False. CPU will be used.`  <br/>A: This error indicates that PyTorch could not find a CUDA-compatible GPU. Either you have no compatible GPU or the necessary CUDA requirements are missing. Using `conda`, you can install them with `conda install cudatoolkit`. For more detailed installation instructions, please refer to the [PyTorch documentation](https://pytorch.org/get-started/locally/).
+  1. Q: `Error enabling CUDA. cuda.is_available() returned False. CPU will be used.`  <br/>A: This error indicates that PyTorch could not find a CUDA-compatible GPU. Either you have no compatible GPU or your PyTorch build has no CUDA support. Install a CUDA-enabled PyTorch build following the [PyTorch install guide](https://pytorch.org/get-started/locally/).
 
 
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,17 @@ It is also available on conda-forge:
    conda install torchquad -c conda-forge
    ```
 
-**Adding a backend (CPU).** torchquad ships convenience extras that pull in the
-CPU build of a backend from the default package index:
+**Adding a backend.** torchquad ships convenience extras that pull a backend
+from the default package index:
    ```sh
-   pip install "torchquad[torch]"        # PyTorch (CPU)
+   pip install "torchquad[torch]"        # PyTorch — CPU on macOS/Windows, CUDA on Linux
    pip install "torchquad[jax]"          # JAX (CPU)
    pip install "torchquad[tensorflow]"   # TensorFlow (CPU)
-   pip install "torchquad[all]"          # all three (CPU)
+   pip install "torchquad[all]"          # all three
    ```
+`jax` and `tensorflow` install CPU builds; `torch`, however, resolves to the
+CUDA build on Linux, because that is what PyTorch publishes to PyPI. For a
+guaranteed-CPU torch, install it from the PyTorch CPU index first.
 
 **Adding a backend (GPU).** These extras cannot select GPU wheels (a Python
 package cannot encode the CUDA-specific index URLs each framework needs), so for

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,12 +11,15 @@ Prerequisites
 *torchquad* is built with
 
 - `autoray <https://github.com/jcmgray/autoray>`_, which means the implemented quadrature supports `NumPy <https://numpy.org/>`_ and can be used for machine learning with modules such as `PyTorch <https://pytorch.org/>`_, `JAX <https://github.com/google/jax/>`_ and `Tensorflow <https://www.tensorflow.org/>`_, where it is fully differentiable
-- `conda <https://docs.conda.io/en/latest/>`_, which will take care of all requirements for you
 
-We recommend using `conda <https://docs.conda.io/en/latest/>`_, especially if you want to utilize the GPU.
-With PyTorch it will automatically set up CUDA and the cudatoolkit for you, for example.
+torchquad has no backend pinned as a hard dependency — install the numerical
+backend(s) you want alongside it, or use NumPy alone. Any of `pip
+<https://pip.pypa.io/>`_, `uv <https://docs.astral.sh/uv/>`_, or `conda
+<https://docs.conda.io/en/latest/>`_ works.
 Note that *torchquad* also works on the CPU; however, it is optimized for GPU usage.
-torchquad's GPU support is tested only on NVIDIA cards with CUDA. We are investigating future support for AMD cards through `ROCm <https://pytorch.org/blog/pytorch-for-amd-rocm-platform-now-available-as-python-package/>`_.
+GPU support is tested only on NVIDIA cards with CUDA. For GPU installs, follow
+each framework's own install guide — the CPU-only convenience extras below
+cannot select GPU wheels, and JAX/TensorFlow GPU builds are Linux/WSL2-only.
 
 For a detailed list of required packages and packages for numerical backends,
 please refer to the conda environment files `environment.yml <https://github.com/esa/torchquad/blob/main/environment.yml>`_ and
@@ -27,46 +30,47 @@ torchquad requires Python 3.10 or newer. Its CI suite runs on Python 3.12 with J
 Installation
 -------------
 
-First, we must make sure we have `torchquad <https://github.com/esa/torchquad>`_ installed.
-The easiest way to do this is simply to
+Install *torchquad* from PyPI:
+
+   .. code-block:: bash
+
+      pip install torchquad
+      # or, with uv:
+      uv pip install torchquad
+
+It is also available on conda-forge:
 
    .. code-block:: bash
 
       conda install torchquad -c conda-forge
 
-Alternatively, it is also possible to use
+**Adding a backend (CPU).** *torchquad* ships convenience extras that pull in the
+CPU build of a backend from the default package index:
 
    .. code-block:: bash
 
-      pip install torchquad
+      pip install "torchquad[torch]"        # PyTorch (CPU)
+      pip install "torchquad[jax]"          # JAX (CPU)
+      pip install "torchquad[tensorflow]"   # TensorFlow (CPU)
+      pip install "torchquad[all]"          # all three (CPU)
 
-The PyTorch backend with CUDA support can be installed with
+**Adding a backend (GPU).** These extras cannot select GPU wheels (a Python
+package cannot encode the CUDA-specific index URLs each framework needs), so for
+GPU support install the backend from its own guide first, then
+``pip install torchquad``:
 
-   .. code-block:: bash
+- PyTorch: https://pytorch.org/get-started/locally/
+- JAX (Linux/WSL2 only): https://docs.jax.dev/en/latest/installation.html
+- TensorFlow (Linux/WSL2 only): https://www.tensorflow.org/install/gpu
 
-      conda install "cudatoolkit>=11.1" "pytorch>=2.1=*cuda*" -c conda-forge -c pytorch
-
-Note that since PyTorch is not yet on *conda-forge* for Windows, we have
-explicitly included it here using ``-c pytorch``.
-Note also that installing PyTorch with *pip* may **not** set it up with CUDA
-support.
-Therefore, we recommend to use *conda*.
-
-Here are installation instructions for other numerical backends:
-
-   .. code-block:: bash
-
-      conda install "tensorflow>=2.6.0=cuda*" -c conda-forge
-      pip install "jax[cuda]>=0.4.17" --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html # linux only
-      conda install "numpy>=1.19.5" -c conda-forge
-
-More installation instructions for numerical backends can be found in
+For a full multi-backend setup, the conda file
 `environment_all_backends.yml <https://github.com/esa/torchquad/blob/main/environment_all_backends.yml>`__
-and at the backend documentations, for example
-https://pytorch.org/get-started/locally/,
-https://github.com/google/jax/#installation and
-https://www.tensorflow.org/install/gpu, and often there are multiple
-ways to install them.
+installs every backend (CPU) in one step:
+
+   .. code-block:: bash
+
+      conda env create -f environment_all_backends.yml
+      conda activate torchquad
 
 
 Usage

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -44,15 +44,18 @@ It is also available on conda-forge:
 
       conda install torchquad -c conda-forge
 
-**Adding a backend (CPU).** *torchquad* ships convenience extras that pull in the
-CPU build of a backend from the default package index:
+**Adding a backend.** *torchquad* ships convenience extras that pull a backend
+from the default package index. ``jax`` and ``tensorflow`` install CPU builds;
+``torch`` resolves to the CUDA build on Linux (that is what PyTorch publishes to
+PyPI), and CPU on macOS/Windows. For a guaranteed-CPU torch, install it from the
+PyTorch CPU index first.
 
    .. code-block:: bash
 
-      pip install "torchquad[torch]"        # PyTorch (CPU)
+      pip install "torchquad[torch]"        # PyTorch (CUDA on Linux, CPU elsewhere)
       pip install "torchquad[jax]"          # JAX (CPU)
       pip install "torchquad[tensorflow]"   # TensorFlow (CPU)
-      pip install "torchquad[all]"          # all three (CPU)
+      pip install "torchquad[all]"          # all three
 
 **Adding a backend (GPU).** These extras cannot select GPU wheels (a Python
 package cannot encode the CUDA-specific index URLs each framework needs), so for

--- a/environment_all_backends.yml
+++ b/environment_all_backends.yml
@@ -1,7 +1,10 @@
+# Full multi-backend environment (PyTorch, JAX, TensorFlow, NumPy) used by CI
+# and for local all-backends development. CPU builds throughout — see the GPU
+# notes below. pip/uv is the primary path (see README); this conda file is the
+# maintained conda path.
 name: torchquad
 channels:
   - conda-forge
-  - pytorch
 dependencies:
   - autoray>=0.5.0
   - loguru>=0.5.3
@@ -12,13 +15,15 @@ dependencies:
   - sphinx>=3.4.3
   - sphinx_rtd_theme>=0.5.1
   - tqdm>=4.56.0
-  # Numerical backend installations with CUDA support where possible:
+  # Numerical backends. conda-forge now ships PyTorch directly, so the separate
+  # `pytorch` channel (deprecated since torch 2.6) and the legacy `cudatoolkit`
+  # pin are gone. This installs the CPU build; for a CUDA build use the
+  # `pytorch-gpu` conda-forge package or follow https://pytorch.org/get-started.
   - numpy>=1.19.5
-  - cudatoolkit>=11.1
-  - pytorch>=2.1 # CPU version
-  # jaxlib with CUDA support is not available for conda
+  - pytorch>=2.1
   - pip:
-      - --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-      - tensorflow>=2.18.0 # CPU version
-      - jax[cpu]>=0.4.17 # this will only work on linux. for win see e.g. https://github.com/cloudhan/jax-windows-builder
-        # CPU version
+      # JAX and TensorFlow come from PyPI (CPU wheels). The obsolete
+      # jax_releases find-links is no longer needed; for JAX/TF GPU (Linux/WSL2
+      # only) follow their own install guides.
+      - tensorflow>=2.18.0
+      - jax[cpu]>=0.4.17

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,17 @@ dependencies = [
     "autoray>=0.5.0",
 ]
 
-# PEP 508 cannot encode per-index URLs, so the backend extras below install only
-# the default-index CPU builds. For GPU/accelerator builds, follow each
-# framework's own install guide (they need CUDA/ROCm-specific wheels and index
-# URLs that a plain extra cannot express). JAX and TensorFlow GPU wheels are
-# Linux/WSL2-only.
+# PEP 508 cannot encode per-index URLs, so the backend extras below install
+# from the default package index. `jax[cpu]` and `tensorflow` are CPU builds;
+# `torch`, however, is CPU on macOS/Windows but the CUDA build on Linux (that is
+# how PyTorch publishes to PyPI). For a guaranteed-CPU torch, or for any GPU
+# build, follow each framework's own install guide (they need CUDA/ROCm-specific
+# wheels and index URLs a plain extra cannot express). JAX and TensorFlow GPU
+# wheels are Linux/WSL2-only.
 [project.optional-dependencies]
-# Development toolchain — mirrors the CI lint + test gates. Version floors track
-# the pins used in the CI workflows; bump both together.
+# Development toolchain for the CI lint + test gates. ruff, pydoclint, vulture,
+# and pytest floors match the versions pinned in the CI workflows; the rest are
+# reasonable minimums, not lockstep pins.
 dev = [
     "pytest>=6.2.1",
     "pytest-cov>=4.0.0",
@@ -53,15 +56,16 @@ docs = [
     "sphinx>=3.4.3",
     "sphinx_rtd_theme>=0.5.1",
 ]
-# CPU/default-index backend conveniences. For GPU support, install the framework
-# from its own guide instead of using these extras.
+# Default-index backend conveniences (see the note above: torch is CUDA on
+# Linux). For a guaranteed CPU torch or any GPU build, use the framework's guide.
 torch = ["torch>=2.1"]
 jax = ["jax[cpu]>=0.4.17"]
 tensorflow = ["tensorflow>=2.18.0"]
+# Recursive extras keep the backend floors defined in exactly one place each.
 all = [
-    "torch>=2.1",
-    "jax[cpu]>=0.4.17",
-    "tensorflow>=2.18.0",
+    "torchquad[torch]",
+    "torchquad[jax]",
+    "torchquad[tensorflow]",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,40 @@ dependencies = [
     "autoray>=0.5.0",
 ]
 
+# PEP 508 cannot encode per-index URLs, so the backend extras below install only
+# the default-index CPU builds. For GPU/accelerator builds, follow each
+# framework's own install guide (they need CUDA/ROCm-specific wheels and index
+# URLs that a plain extra cannot express). JAX and TensorFlow GPU wheels are
+# Linux/WSL2-only.
+[project.optional-dependencies]
+# Development toolchain — mirrors the CI lint + test gates. Version floors track
+# the pins used in the CI workflows; bump both together.
+dev = [
+    "pytest>=6.2.1",
+    "pytest-cov>=4.0.0",
+    "pytest-error-for-skips>=2.0.2",
+    "ruff>=0.14.6",
+    "pydoclint>=0.8.3",
+    "vulture>=2.14",
+    "pre-commit>=3.5.0",
+    "build>=1.0.0",
+    "twine>=4.0.0",
+]
+docs = [
+    "sphinx>=3.4.3",
+    "sphinx_rtd_theme>=0.5.1",
+]
+# CPU/default-index backend conveniences. For GPU support, install the framework
+# from its own guide instead of using these extras.
+torch = ["torch>=2.1"]
+jax = ["jax[cpu]>=0.4.17"]
+tensorflow = ["tensorflow>=2.18.0"]
+all = [
+    "torch>=2.1",
+    "jax[cpu]>=0.4.17",
+    "tensorflow>=2.18.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/esa/torchquad"
 Source = "https://github.com/esa/torchquad/"


### PR DESCRIPTION
## Summary
- Adds `[project.optional-dependencies]` extras: `dev`, `docs`, and CPU-convenience backend extras (`torch`, `jax`, `tensorflow`, `all`). GPU builds stay out of scope for extras — PEP 508 cannot encode the per-index URLs each framework needs (C5).
- Rewrites the install docs (README + `install.rst`) to lead with pip/uv, drop the deprecated `pytorch` conda channel and the stale ROCm "investigating" line, and point GPU users at each framework's own guide (C6).
- Repairs `environment_all_backends.yml`: drops the dead `pytorch` channel, legacy `cudatoolkit`, and obsolete jax find-links; rebuilds on conda-forge (C7).

Part of the 0.6 packaging/CI modernization. Related to the roadmap items C5–C7.

## Test plan
- [x] `pyproject.toml` parses; all six extras resolve as valid PEP 508 requirement lists.
- [x] Both env YAMLs parse; channels reduced to `conda-forge` only.
- [x] CI (lint + all-backends tests) green on this branch.
