### PR TITLE
docs: fix stale badges and Built With tooling line

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The software is free to use and is designed for the machine learning community a
 This project is built with the following packages:
 
 * [autoray](https://github.com/jcmgray/autoray), which means the implemented quadrature supports [NumPy](https://numpy.org/) and can be used for machine learning with modules such as [PyTorch](https://pytorch.org/), [JAX](https://github.com/google/jax/) and [Tensorflow](https://www.tensorflow.org/), where it is fully differentiable
-* [conda](https://docs.conda.io/en/latest/), which will take care of all requirements for you
+* [uv](https://docs.astral.sh/uv/) or [conda](https://docs.conda.io/en/latest/), either of which can set up the required environment for you
 
 
 If torchquad proves useful to you, please consider citing the [accompanying paper](https://joss.theoj.org/papers/10.21105/joss.03439).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@
    :alt: Tests
 
 .. image:: https://img.shields.io/github/last-commit/esa/torchquad
-   :target: https://github.com/esa/torchquad/commits
+   :target: https://github.com/esa/torchquad/commits/main
    :alt: GitHub last commit
 
 .. image:: https://img.shields.io/github/license/esa/torchquad

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,48 +14,48 @@
    :target: https://torchquad.readthedocs.io/en/main/?badge=main
    :alt: Documentation Status
 
-.. image:: https://img.shields.io/github/workflow/status/esa/torchquad/Running%20tests/develop
-   :target: https://img.shields.io/github/workflow/status/esa/torchquad/Running%20tests/develop
-   :alt: GitHub Workflow Status (branch)
+.. image:: https://github.com/esa/torchquad/actions/workflows/run_tests.yml/badge.svg
+   :target: https://github.com/esa/torchquad/actions/workflows/run_tests.yml
+   :alt: Tests
 
 .. image:: https://img.shields.io/github/last-commit/esa/torchquad
-   :target: https://img.shields.io/github/last-commit/esa/torchquad
+   :target: https://github.com/esa/torchquad/commits
    :alt: GitHub last commit
 
 .. image:: https://img.shields.io/github/license/esa/torchquad
-   :target: https://img.shields.io/github/license/esa/torchquad
+   :target: https://github.com/esa/torchquad/blob/main/LICENSE
    :alt: GitHub license
 
 .. image:: https://img.shields.io/conda/vn/conda-forge/torchquad
-   :target: https://img.shields.io/conda/vn/conda-forge/torchquad
+   :target: https://anaconda.org/conda-forge/torchquad
    :alt: Conda (channel only)
 
 .. image:: https://img.shields.io/pypi/v/torchquad
-   :target: https://img.shields.io/pypi/v/torchquad
+   :target: https://pypi.org/project/torchquad/
    :alt: PyPI Version
 
 .. image:: https://img.shields.io/pypi/pyversions/torchquad
-   :target: https://img.shields.io/pypi/pyversions/torchquad
+   :target: https://pypi.org/project/torchquad/
    :alt: PyPI - Python Version
 
 .. image:: https://img.shields.io/github/contributors/esa/torchquad
-   :target: https://img.shields.io/github/contributors/esa/torchquad
+   :target: https://github.com/esa/torchquad/graphs/contributors
    :alt: GitHub contributors
 
 .. image:: https://img.shields.io/github/issues/esa/torchquad
-   :target: https://img.shields.io/github/issues/esa/torchquad
+   :target: https://github.com/esa/torchquad/issues
    :alt: GitHub issues
 
 .. image:: https://img.shields.io/github/issues-pr/esa/torchquad
-   :target: https://img.shields.io/github/issues-pr/esa/torchquad
+   :target: https://github.com/esa/torchquad/pulls
    :alt: GitHub pull requests
 
 .. image:: https://img.shields.io/conda/dn/conda-forge/torchquad
-   :target: https://img.shields.io/conda/dn/conda-forge/torchquad
+   :target: https://anaconda.org/conda-forge/torchquad
    :alt: Conda
 
 .. image:: https://img.shields.io/pypi/dm/torchquad
-   :target: https://img.shields.io/pypi/dm/torchquad
+   :target: https://pypi.org/project/torchquad/
    :alt: PyPI - Downloads
 
 .. image:: https://joss.theoj.org/papers/d6f22f83f1a889ddf83b3c2e0cd0919c/status.svg


### PR DESCRIPTION
## What

Truth-pass tail for the 0.6 docs work:

- The docs index carried a **dead Actions badge** using the removed
  `img.shields.io/github/workflow/status/...` endpoint. Replaced with the current
  `run_tests.yml` badge (same one the README uses).
- Every docs badge `:target:` pointed at the shields.io **image URL**, so clicking
  a badge showed raw SVG. Repointed each to its real destination (Actions runs,
  PyPI project, conda-forge, GitHub commits/issues/pulls/contributors/LICENSE).
- README "Built With" no longer implies conda is the only environment tool; it now
  mentions uv/conda, consistent with the pip/uv-lead install section.

Verified torchquad is in fact published on conda-forge (0.5.0), so the conda
badges are kept.

## Test plan

- [x] `sphinx-build -W -b html docs/source` builds clean (docs CI gate)

Part of the 0.6 cleanup series (R7).
