### PR TITLE
feat: add opt-in VEGAS error reporting (return_error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The 0.6 line is a modernization and credibility release: modern tooling, honest
 packaging, and closing long-open fixed issues.
 
 ### Added
+- `VEGAS.integrate(..., return_error=True)` returns a `VEGASResult` bundling the
+  integral with its error estimate (standard deviation, chi-squared, degrees of
+  freedom and goodness-of-fit Q) instead of discarding them.
 - Optional-dependency extras: `dev`, `docs`, and CPU-convenience backend extras
   `torch`, `jax`, `tensorflow`, `all`.
 - `release_testing/` suite — slower end-to-end checks run against the latest

--- a/tests/vegas_result_test.py
+++ b/tests/vegas_result_test.py
@@ -52,9 +52,14 @@ def _vegas_result_fields_test(backend, dtype_name=None):
         f"Error estimate {sdev} does not bracket the true error {abs(integral - _EXPECTED)}"
     )
 
-    # Degrees of freedom and goodness-of-fit are well-formed.
+    # Degrees of freedom and goodness-of-fit are well-formed, and Q matches an
+    # independent evaluation of the chi-squared survival function (guards against
+    # a swapped-argument or wrong-formula regression, not just a plausible range).
+    from scipy.special import gammaincc
+
     assert result.dof >= 1
     assert result.Q is not None and 0.0 <= result.Q <= 1.0
+    assert abs(result.Q - float(gammaincc(result.dof / 2.0, chi2 / 2.0))) < 1e-12
     assert result.nr_of_fevals > 0
     # __repr__ must not raise.
     assert "VEGASResult" in repr(result)

--- a/tests/vegas_result_test.py
+++ b/tests/vegas_result_test.py
@@ -1,0 +1,123 @@
+"""Tests for VEGAS error reporting via ``return_error=True``.
+
+VEGAS already computes an error estimate, chi-squared and goodness-of-fit
+internally; ``return_error=True`` surfaces them as a :class:`VEGASResult` instead
+of discarding them. VEGAS supports only the numpy and torch backends.
+"""
+
+import numpy as np
+from autoray import numpy as anp
+
+from torchquad.integration.vegas import VEGAS
+from torchquad.integration.vegas_result import VEGASResult
+from helper_functions import setup_test_for_backend
+
+# prod_i sin(x_i) over [0, pi]^2 integrates to 2^2 = 4.
+_DIM = 2
+_N = 40000
+_DOMAIN = [[0.0, np.pi], [0.0, np.pi]]
+_EXPECTED = 4.0
+
+
+def _to_float(result):
+    """Convert a scalar backend tensor (possibly on GPU) to a Python float."""
+    if hasattr(result, "cpu"):
+        result = result.cpu()
+    return float(np.asarray(result))
+
+
+def _integrand(x):
+    return anp.prod(anp.sin(x), axis=1)
+
+
+def _vegas_result_fields_test(backend, dtype_name=None):
+    """return_error=True must yield a well-formed, self-consistent VEGASResult."""
+    result = VEGAS().integrate(
+        _integrand, dim=_DIM, N=_N, integration_domain=_DOMAIN, seed=0, return_error=True
+    )
+    assert isinstance(result, VEGASResult)
+
+    integral = _to_float(result.integral)
+    sdev = _to_float(result.sdev)
+    chi2 = _to_float(result.chi2)
+
+    # The integral is accurate and the reported error is a sane, positive number.
+    assert abs(integral - _EXPECTED) < 0.05, f"VEGAS integral {integral} far from {_EXPECTED}"
+    assert 0.0 < sdev < 0.05, f"Unreasonable VEGAS sdev {sdev}"
+    assert chi2 >= 0.0
+
+    # The error estimate must actually bracket the truth (generous factor to stay
+    # robust to GPU-reduction non-determinism, not so loose as to be meaningless).
+    assert abs(integral - _EXPECTED) < 8.0 * sdev, (
+        f"Error estimate {sdev} does not bracket the true error {abs(integral - _EXPECTED)}"
+    )
+
+    # Degrees of freedom and goodness-of-fit are well-formed.
+    assert result.dof >= 1
+    assert result.Q is not None and 0.0 <= result.Q <= 1.0
+    assert result.nr_of_fevals > 0
+    # __repr__ must not raise.
+    assert "VEGASResult" in repr(result)
+
+
+def _vegas_backward_compat_test(backend, dtype_name=None):
+    """The default (return_error=False) must still return the bare integral."""
+    result = VEGAS().integrate(_integrand, dim=_DIM, N=_N, integration_domain=_DOMAIN, seed=0)
+    assert not isinstance(result, VEGASResult)
+    assert abs(_to_float(result) - _EXPECTED) < 0.05
+
+
+def _vegas_result_matches_bare_test(backend, dtype_name=None):
+    """The bundled integral must equal the bare integral for the same run.
+
+    numpy only: its RNG is instance-local and its reductions are deterministic,
+    so two identically-seeded runs agree bit-for-bit. (torch here runs on the GPU,
+    whose reductions are not bit-reproducible.)
+    """
+    bare = VEGAS().integrate(_integrand, dim=_DIM, N=_N, integration_domain=_DOMAIN, seed=3)
+    bundled = VEGAS().integrate(
+        _integrand, dim=_DIM, N=_N, integration_domain=_DOMAIN, seed=3, return_error=True
+    )
+    assert _to_float(bundled.integral) == _to_float(bare)
+
+
+def _vegas_determinism_test(backend, dtype_name=None):
+    """A fixed seed reproduces the integral and its error (numpy only, see above)."""
+    first = VEGAS().integrate(
+        _integrand, dim=_DIM, N=_N, integration_domain=_DOMAIN, seed=11, return_error=True
+    )
+    second = VEGAS().integrate(
+        _integrand, dim=_DIM, N=_N, integration_domain=_DOMAIN, seed=11, return_error=True
+    )
+    assert _to_float(first.integral) == _to_float(second.integral)
+    assert _to_float(first.sdev) == _to_float(second.sdev)
+
+
+test_vegas_result_fields_numpy = setup_test_for_backend(
+    _vegas_result_fields_test, "numpy", "float64"
+)
+test_vegas_result_fields_torch = setup_test_for_backend(
+    _vegas_result_fields_test, "torch", "float64"
+)
+
+test_vegas_backward_compat_numpy = setup_test_for_backend(
+    _vegas_backward_compat_test, "numpy", "float64"
+)
+test_vegas_backward_compat_torch = setup_test_for_backend(
+    _vegas_backward_compat_test, "torch", "float64"
+)
+
+# numpy-only: bit-for-bit equality/reproducibility (see docstrings).
+test_vegas_result_matches_bare_numpy = setup_test_for_backend(
+    _vegas_result_matches_bare_test, "numpy", "float64"
+)
+test_vegas_determinism_numpy = setup_test_for_backend(_vegas_determinism_test, "numpy", "float64")
+
+
+if __name__ == "__main__":
+    for _backend in ["numpy", "torch"]:
+        _vegas_result_fields_test(_backend)
+        _vegas_backward_compat_test(_backend)
+    _vegas_result_matches_bare_test("numpy")
+    _vegas_determinism_test("numpy")
+    print("All VEGAS result tests passed!")

--- a/tests/vegas_result_test.py
+++ b/tests/vegas_result_test.py
@@ -10,7 +10,7 @@ from autoray import numpy as anp
 
 from torchquad.integration.vegas import VEGAS
 from torchquad.integration.vegas_result import VEGASResult
-from helper_functions import setup_test_for_backend
+from helper_functions import get_test_functions, setup_test_for_backend
 
 # prod_i sin(x_i) over [0, pi]^2 integrates to 2^2 = 4.
 _DIM = 2
@@ -98,6 +98,47 @@ def _vegas_determinism_test(backend, dtype_name=None):
     assert _to_float(first.sdev) == _to_float(second.sdev)
 
 
+def _vegas_error_calibration_test(backend, dtype_name=None):
+    """VEGAS's reported error must bracket the true error across the whole collection.
+
+    For every real, scalar-integrand analytic test function (VEGAS supports only
+    real, non-vectorized integrands, so complex and multi-integrand functions are
+    skipped) the estimated ``sdev`` has to be a meaningful error bar: VEGAS
+    converges to the closed-form value, and the actual error stays within a few
+    ``sdev`` of it. Validates the estimate against ground truth rather than merely
+    range-checking it.
+    """
+    for integration_dim, N in [(1, 40000), (3, 60000)]:
+        for test_function in get_test_functions(
+            integration_dim, backend, use_multi_dim_integrand=False
+        ):
+            if test_function.is_complex or not test_function.is_integrand_1d:
+                continue
+            result = test_function.evaluate(
+                VEGAS().integrate,
+                {"dim": integration_dim, "N": N, "seed": 0, "return_error": True},
+            )
+            exact = float(np.asarray(test_function.expected_result))
+            integral = _to_float(result.integral)
+            sdev = _to_float(result.sdev)
+            true_error = abs(integral - exact)
+
+            label = f"{type(test_function).__name__} dim={integration_dim}"
+            assert sdev > 0.0, f"{label}: non-positive sdev"
+            assert result.dof >= 1
+            assert result.Q is not None and 0.0 <= result.Q <= 1.0
+            # VEGAS actually converged on this function (worst observed ~0.8%).
+            assert true_error < 0.05 * max(abs(exact), 1.0), (
+                f"{label}: VEGAS did not converge, error {true_error}"
+            )
+            # ...and its self-reported sdev brackets the true error. The worst
+            # true_error/sdev observed across the collection is ~3.4; 8x leaves
+            # headroom for the stochastic (and GPU-nondeterministic) spread.
+            assert true_error < 8.0 * sdev, (
+                f"{label}: true error {true_error} exceeds 8*sdev = {8.0 * sdev}"
+            )
+
+
 test_vegas_result_fields_numpy = setup_test_for_backend(
     _vegas_result_fields_test, "numpy", "float64"
 )
@@ -112,6 +153,13 @@ test_vegas_backward_compat_torch = setup_test_for_backend(
     _vegas_backward_compat_test, "torch", "float64"
 )
 
+test_vegas_error_calibration_numpy = setup_test_for_backend(
+    _vegas_error_calibration_test, "numpy", "float64"
+)
+test_vegas_error_calibration_torch = setup_test_for_backend(
+    _vegas_error_calibration_test, "torch", "float64"
+)
+
 # numpy-only: bit-for-bit equality/reproducibility (see docstrings).
 test_vegas_result_matches_bare_numpy = setup_test_for_backend(
     _vegas_result_matches_bare_test, "numpy", "float64"
@@ -123,6 +171,7 @@ if __name__ == "__main__":
     for _backend in ["numpy", "torch"]:
         _vegas_result_fields_test(_backend)
         _vegas_backward_compat_test(_backend)
+        _vegas_error_calibration_test(_backend)
     _vegas_result_matches_bare_test("numpy")
     _vegas_determinism_test("numpy")
     print("All VEGAS result tests passed!")

--- a/torchquad/__init__.py
+++ b/torchquad/__init__.py
@@ -20,6 +20,7 @@ from .integration.trapezoid import Trapezoid
 from .integration.simpson import Simpson
 from .integration.boole import Boole
 from .integration.vegas import VEGAS
+from .integration.vegas_result import VEGASResult
 from .integration.gaussian import GaussLegendre
 from .integration.gaussian import Gaussian
 from .integration.grid_integrator import GridIntegrator
@@ -44,6 +45,7 @@ __all__ = [
     "Simpson",
     "Boole",
     "VEGAS",
+    "VEGASResult",
     "GaussLegendre",
     "Gaussian",
     "RNG",

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -371,11 +371,14 @@ class VEGAS(BaseIntegrator):
             backend-specific float: Chi squared.
         """
         I_final = self._get_result()
+        # Skip zero-variance iterations (as _get_result and _get_error do): a
+        # zero divisor would make chi-squared inf, which return_error now exposes
+        # to users as chi2/Q.
         return sum(
             (
                 (res - I_final) ** 2 / sig2
                 for res, sig2 in zip(self.results, self.sigma2)
-                if res != I_final
+                if res != I_final and sig2 != 0.0
             ),
             start=self.results[0] * 0.0,
         )

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -8,6 +8,7 @@ from .utils import _setup_integration_domain
 from .rng import RNG
 from .vegas_map import VEGASMap
 from .vegas_stratification import VEGASStratification
+from .vegas_result import VEGASResult, goodness_of_fit_q
 
 
 class VEGAS(BaseIntegrator):
@@ -41,6 +42,7 @@ class VEGAS(BaseIntegrator):
         max_iterations=20,
         use_warmup=True,
         backend=None,
+        return_error=False,
     ):
         """Integrates the passed function on the passed domain using VEGAS.
 
@@ -60,12 +62,14 @@ class VEGAS(BaseIntegrator):
             max_iterations (int, optional): Maximum number of vegas iterations to perform. The number of performed iterations is usually lower than this value because the number of sample points per iteration increases every fifth iteration. Defaults to 20.
             use_warmup (bool, optional): If True, execute a warmup to initialize the vegas map. Defaults to True.
             backend (string, optional): Numerical backend. "jax" and "tensorflow" are unsupported. Defaults to integration_domain's backend if it is a tensor and otherwise to the backend from the latest call to set_up_backend or "torch" for backwards compatibility.
+            return_error (bool, optional): If True, return a :class:`VEGASResult` bundling the integral with its error estimate (standard deviation, chi-squared, degrees of freedom and goodness-of-fit Q) instead of the bare integral value. Defaults to False.
 
         Raises:
             ValueError: If the integration_domain or backend argument is invalid
 
         Returns:
-            backend-specific float: Integral value
+            backend-specific float or VEGASResult: Integral value, or a
+            :class:`VEGASResult` with the error estimate if ``return_error`` is True.
         """
 
         self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
@@ -156,7 +160,22 @@ class VEGAS(BaseIntegrator):
         logger.info(
             f"Computed integral after {self._nr_of_fevals} evals was {self._get_result():.8e}."
         )
-        return self._get_result()
+        if not return_error:
+            return self._get_result()
+
+        # The result/variance windows are reset every fifth iteration, so these
+        # errors reflect the same final window of iterations that _get_result
+        # combines (dof = combined iterations minus one).
+        dof = max(len(self.results) - 1, 0)
+        chi2 = self._get_chisq()
+        return VEGASResult(
+            integral=self._get_result(),
+            sdev=self._get_error(),
+            chi2=chi2,
+            dof=dof,
+            Q=goodness_of_fit_q(chi2, dof),
+            nr_of_fevals=self._nr_of_fevals,
+        )
 
     def _check_abort_conditions(self):
         """Test if VEGAS should execute more iterations or stop,

--- a/torchquad/integration/vegas_result.py
+++ b/torchquad/integration/vegas_result.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+def goodness_of_fit_q(chi2, dof):
+    """Compute the VEGAS goodness-of-fit p-value Q.
+
+    Q is the probability that a chi-squared statistic with ``dof`` degrees of
+    freedom exceeds the observed ``chi2`` purely by chance. Values close to 1
+    indicate the per-iteration estimates are consistent with each other; values
+    close to 0 indicate the error estimate should not be trusted.
+
+    Args:
+        chi2 (backend scalar): Observed chi-squared of the iteration estimates.
+        dof (int): Degrees of freedom (combined iterations minus one).
+
+    Returns:
+        float or None: The p-value in [0, 1], or None if ``dof`` is not positive
+        (a single iteration carries no goodness-of-fit information).
+    """
+    if dof <= 0:
+        return None
+    # Regularized upper incomplete gamma = survival function of the chi-squared
+    # distribution. SciPy is already a hard dependency.
+    from scipy.special import gammaincc
+
+    return float(gammaincc(dof / 2.0, float(chi2) / 2.0))
+
+
+@dataclass
+class VEGASResult:
+    """A VEGAS integration result bundled with its error estimate.
+
+    Returned by :meth:`VEGAS.integrate` when ``return_error=True``. The
+    tensor-valued fields keep the numerical backend of the integration so they
+    remain differentiable.
+    """
+
+    integral: Any
+    """backend scalar: Estimated integral (weighted mean over combined iterations)."""
+
+    sdev: Any
+    """backend scalar: Estimated 1-sigma standard deviation of the integral."""
+
+    chi2: Any
+    """backend scalar: Chi-squared of the per-iteration estimates about their weighted mean."""
+
+    dof: int
+    """int: Degrees of freedom, i.e. the number of combined iterations minus one."""
+
+    Q: Optional[float]
+    """float or None: Goodness-of-fit p-value ``P(chi2 >= observed | dof)``; None if ``dof <= 0``."""
+
+    nr_of_fevals: int
+    """int: Number of integrand evaluations performed."""
+
+    def __repr__(self):
+        """Return a compact ``value +/- sdev (chi2/dof = ..., Q = ...)`` summary."""
+        chi2_over_dof = float(self.chi2) / self.dof if self.dof > 0 else float("nan")
+        q_text = "n/a" if self.Q is None else f"{self.Q:.2g}"
+        return (
+            f"VEGASResult({float(self.integral):.6g} +/- {float(self.sdev):.2g}, "
+            f"chi2/dof = {chi2_over_dof:.2g}, Q = {q_text})"
+        )

--- a/torchquad/integration/vegas_result.py
+++ b/torchquad/integration/vegas_result.py
@@ -32,8 +32,10 @@ class VEGASResult:
     """A VEGAS integration result bundled with its error estimate.
 
     Returned by :meth:`VEGAS.integrate` when ``return_error=True``. The
-    tensor-valued fields keep the numerical backend of the integration so they
-    remain differentiable.
+    tensor-valued fields keep the numerical backend of the integration. Only
+    ``integral`` is on the gradient path; ``sdev`` and ``chi2`` are derived from
+    the per-iteration variances, which VEGAS detaches, so they are not
+    differentiable.
     """
 
     integral: Any


### PR DESCRIPTION
## What

VEGAS already computes a standard deviation, chi-squared and goodness-of-fit
internally, then threw them away and returned only the bare integral. This adds
an opt-in `return_error=True` that surfaces them:

```python
from torchquad import VEGAS
result = VEGAS().integrate(fn, dim=2, N=40000, integration_domain=dom, return_error=True)
print(result)        # VEGASResult(4.00144 +/- 0.0014, chi2/dof = 1, Q = 0.41)
result.integral, result.sdev, result.chi2, result.dof, result.Q
```

- New `VEGASResult` dataclass (`integral`, `sdev`, `chi2`, `dof`, `Q`,
  `nr_of_fevals`) with a compact `value +/- sdev (chi2/dof, Q)` repr; `Q` is the
  chi-squared goodness-of-fit p-value via SciPy's regularized upper incomplete
  gamma. Exposed as `torchquad.VEGASResult`.
- The tensor fields keep the integration backend. Only `integral` is on the
  gradient path; `sdev`/`chi2` derive from VEGAS's detached variances and are
  not differentiable.
- `return_error` defaults to `False` → the existing bare-value return is
  unchanged (no breaking change).

## Test plan

- [x] `vegas_result_test.py` (numpy + torch): result fields well-formed and
  self-consistent, error estimate brackets the true error, backward-compatible
  default return; numpy bit-for-bit reproducibility (torch bit-reproducibility
  isn't asserted — GPU reductions aren't deterministic)
- [x] existing `vegas_test.py` still green
- [x] `ruff` / `pydoclint` / `vulture` clean; `sphinx-build -W` builds
  (`VEGASResult` auto-documented via `__all__`, per-field attribute docstrings)

Roadmap F2.
